### PR TITLE
sql for aggregated-epic-views table

### DIFF
--- a/sql/create-aggregated-epic-views-table.sql
+++ b/sql/create-aggregated-epic-views-table.sql
@@ -2,6 +2,7 @@ CREATE EXTERNAL TABLE IF NOT EXISTS acquisition.aggregated-epic-views-prod (
   `url` string,
   `views` int
 )
+PARTITIONED BY (dt string)
 ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
 WITH SERDEPROPERTIES (
   'serialization.format' = '1'

--- a/sql/create-aggregated-epic-views-table.sql
+++ b/sql/create-aggregated-epic-views-table.sql
@@ -5,6 +5,6 @@ CREATE EXTERNAL TABLE IF NOT EXISTS acquisition.aggregated-epic-views-prod (
 ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
 WITH SERDEPROPERTIES (
   'serialization.format' = '1'
-) LOCATION 's3://support-aggregated-epic-views/PROD/'
+) LOCATION 's3://gu-support-analytics/aggregated-epic-views/PROD/'
 TBLPROPERTIES ('has_encrypted_data'='false');
 

--- a/sql/create-aggregated-epic-views-table.sql
+++ b/sql/create-aggregated-epic-views-table.sql
@@ -1,4 +1,4 @@
-CREATE EXTERNAL TABLE IF NOT EXISTS acquisition.aggregated-epic-views-prod (
+CREATE EXTERNAL TABLE IF NOT EXISTS acquisition.aggregated_epic_views_prod (
   `url` string,
   `views` int
 )

--- a/sql/create-aggregated-epic-views-table.sql
+++ b/sql/create-aggregated-epic-views-table.sql
@@ -1,0 +1,10 @@
+CREATE EXTERNAL TABLE IF NOT EXISTS acquisition.aggregated-epic-views-prod (
+  `url` string,
+  `views` int
+)
+ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
+WITH SERDEPROPERTIES (
+  'serialization.format' = '1'
+) LOCATION 's3://support-aggregated-epic-views/PROD/'
+TBLPROPERTIES ('has_encrypted_data'='false');
+


### PR DESCRIPTION
The partition assumes folder names in s3 have format `dt=2021-04-12-13-00/`.
Athena looks for data in:
`s3://gu-support-analytics/aggregated-epic-views/<STAGE>/`

E.g. of a file:
`s3://gu-support-analytics/aggregated-epic-views/PROD/dt=2021-04-12-13-00/<some_unique_name>.json`

Assumes files contain json data with e.g.:
```
{"url": "https...", "views": 20}
{"url": "https...", "views": 30}
```


For details of partitioning see https://docs.aws.amazon.com/athena/latest/ug/partitions.html