### PR TITLE
update cloudformation for api gateway request validation

### DIFF
--- a/component-event-stream/cfn.yaml
+++ b/component-event-stream/cfn.yaml
@@ -76,12 +76,31 @@ Resources:
         swagger: "2.0"
         info:
           title: !Ref AWS::StackName
+        x-amazon-apigateway-request-validators:
+          body-only:
+            validateRequestBody: true
+            validateRequestParameters: false
+        x-amazon-apigateway-request-validator: body-only
         paths:
           "/epic-view":
             "post":
+              x-amazon-apigateway-request-validator: body-only
+              parameters:
+                - in: body
+                  name: RequestBodyModel
+                  required: true
+                  schema:
+                    $ref: "#/definitions/RequestBodyModel"
               responses:
                 "200":
                   description: "200 response"
+                  schema:
+                    $ref: "#/definitions/Empty"
+                  headers:
+                    Access-Control-Allow-Origin:
+                      type: "string"
+                "400":
+                  description: "400 response"
                   schema:
                     $ref: "#/definitions/Empty"
                   headers:
@@ -105,6 +124,17 @@ Resources:
                 passthroughBehavior: when_no_match
                 type: aws
                 uri: !Sub "arn:aws:apigateway:${AWS::Region}:kinesis:action/PutRecords"
+        definitions:
+          RequestBodyModel:
+            type: object
+            properties:
+              url:
+                type: string
+              countryCode:
+                type: string
+            required: [ url, countryCode ]
+          Error:
+            type: object
 
   DomainName:
     Type: "AWS::ApiGateway::DomainName"


### PR DESCRIPTION
### What does this PR do?
Adds request body validation for epic view events. Request is deemed valid if both `url` and `countryCode` keys present and their values are strings.