### PR TITLE
Update supermode thresholds

### DIFF
--- a/super-mode-calculator/src/lib/constants.ts
+++ b/super-mode-calculator/src/lib/constants.ts
@@ -11,11 +11,11 @@ export const SUPER_MODE_MINIMUM_VIEWS = 100;
 export const SUPER_MODE_MINIMUM_AV = 40;
 
 export const SUPER_MODE_AV_PER_VIEWS_THRESHOLDS = {
-	GB: 0.01,
+	GB: 0.005,
 	US: 0.033,
-	AU: 0.015,
-	NZ: 0.015,
-	CA: 0.02,
-	EU: 0.015,
-	ROW: 0.015,
+	AU: 0.01,
+	NZ: 0.01,
+	CA: 0.015,
+	EU: 0.01,
+	ROW: 0.01,
 };


### PR DESCRIPTION
## What does this change?
Update the supermode thresholds. Here are the requested new thresholds (given as £AV per 1000 views): 

<img width="217" alt="Screenshot 2021-08-26 at 09 30 41" src="https://user-images.githubusercontent.com/17720442/130929507-0c61fd51-ddc4-4b27-9fa2-f519ba3e6880.png">
