### PR TITLE
Alarm for minimum epic views

### DIFF
--- a/component-event-stream/cfn.yaml
+++ b/component-event-stream/cfn.yaml
@@ -164,3 +164,22 @@ Resources:
       ResourceRecords:
         - !GetAtt [ DomainName, RegionalDomainName ]
 
+  EpicViewAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsProd
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:marketing-dev
+      AlarmName: !Sub support-epic-view-event-stream-${Stage} events below minimum threshold
+      AlarmDescription: Epic impressions have dropped below the minimum threshold
+      MetricName: IncomingRecords
+      Namespace: AWS/Kinesis
+      Dimensions:
+        - Name: StreamName
+          Value: !Sub support-epic-view-event-stream-${Stage}
+      ComparisonOperator: LessThanThreshold
+      Threshold: 20000
+      Period: 3600
+      EvaluationPeriods: 1
+      Statistic: Sum
+


### PR DESCRIPTION
We have a kinesis stream for epic view events.
This PR adds an alarm to detect when impressions drop below 20,000 in an hour.

We can also add streams for monitoring other channels, e.g. the banner. But doing this for the epic is a quick win as we're already collecting these events.