### PR TITLE
Enable nightly backups for the super-mode table

### DIFF
--- a/super-mode-calculator/cfn-dynamodb.yaml
+++ b/super-mode-calculator/cfn-dynamodb.yaml
@@ -45,3 +45,6 @@ Resources:
           ProvisionedThroughput:
             ReadCapacityUnits: 5
             WriteCapacityUnits: 5
+      Tags:
+        - Key: devx-backup-enabled
+          Value: true


### PR DESCRIPTION
## What does this change?

This PR allows us to start backing up the super-mode DynamoDB table using https://github.com/guardian/aws-backup. For more details on this project see [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit) and this [audit](https://docs.google.com/spreadsheets/d/1gNh_yQ3GVo_dVAemgZfRZM_MaQxep6_x-hzrhvVBGHY/edit#gid=1523470588) that @guardian/devx-reliability have been working on with Heads of Engineering.

## How to test

I should be able to test this by deploying to `CODE` (see `Deployment` section below).

I will double check that backups are taken as expected after merging (this should happen the night after this PR is merged).

## How can we measure success?

We will be able to recover (most) data stored in this table in the unlikely event that it is deleted.

## Have we considered potential risks?

Yes, a number of risks related to performance, cost and privacy were considered. See [this doc](https://docs.google.com/document/d/11EZtuVHCnjavE9AYLroiuDUsMzbp2ulFBtj4VkyCKNc/edit#heading=h.vwt7syo8ng40) for more details.

## Deployment

As far as I can tell, this CloudFormation stack is deployed manually[^1].

If people are happy with this change in principle, I will:

- [x] Manually update the `CODE` stack via the console (to check that this works)
- [ ] Merge the PR
- [ ] Manually update the `PROD` stack via the console

[^1]: It looks like [Riff-Raff deploys](https://github.com/guardian/support-analytics/blob/d2f5dc28c1660a815ef1e23bf22855db45faff21/super-mode-calculator/riff-raff.yaml#L20) some of the [infrastructure for this app](https://github.com/guardian/support-analytics/blob/d2f5dc28c1660a815ef1e23bf22855db45faff21/super-mode-calculator/cfn.yaml), but not [the tables](https://github.com/guardian/support-analytics/blob/d2f5dc28c1660a815ef1e23bf22855db45faff21/super-mode-calculator/cfn-dynamodb.yaml).