### PR TITLE
Bandit Calculate Lambda - write results of query lambda to dynamo

### DIFF
--- a/bandit/package.json
+++ b/bandit/package.json
@@ -6,7 +6,7 @@
 	"scripts": {
 		"lint": "eslint 'src/**/*.ts'",
 		"build": "tsc",
-		"local": "Stage=CODE ts-node ./src/query-lambda/local.ts",
+		"local": "Stage=CODE AWS_PROFILE=membership ts-node ./src/query-lambda/local.ts",
 		"gbt-local": "Stage=CODE AWS_PROFILE=membership ts-node ./src/get-bandit-tests/local.ts"
 	},
 	"dependencies": {

--- a/bandit/src/calculate-lambda/dynamo.ts
+++ b/bandit/src/calculate-lambda/dynamo.ts
@@ -1,0 +1,60 @@
+import type { AWSError } from "aws-sdk";
+import type { DocumentClient } from "aws-sdk/clients/dynamodb";
+import type { PromiseResult } from "aws-sdk/lib/request";
+import type { VariantQueryRow } from "./parse";
+
+interface VariantModel {
+	variantName: string;
+	avGbpPerView: number;
+}
+
+export interface BanditModel {
+	testName: string;
+	variants: VariantModel[];
+	testNameWithAlgorithm: string;
+	timestamp: string;
+}
+
+export function buildWriteRequest(
+	rows: VariantQueryRow[],
+	testName: string
+): DocumentClient.WriteRequest {
+	return {
+		PutRequest: {
+			Item: buildDynamoRecord(rows, testName),
+		},
+	};
+}
+
+function buildDynamoRecord(
+	rows: VariantQueryRow[],
+	testName: string
+): BanditModel {
+	const variants = rows.map((x) => ({
+		variantName: x.variantName,
+		avGbpPerView: x.avGbpPerView,
+	}));
+
+	return {
+		testName,
+		variants,
+		testNameWithAlgorithm: `${testName}-epsilon-greedy`,
+		timestamp: new Date().toISOString(),
+	};
+}
+
+export function writeBatch(
+	batch: DocumentClient.WriteRequest[],
+	stage: string,
+	docClient: DocumentClient
+): Promise<PromiseResult<DocumentClient.BatchWriteItemOutput, AWSError>> {
+	const table = `support-bandit-${stage.toUpperCase()}`;
+
+	return docClient
+		.batchWrite({
+			RequestItems: {
+				[table]: batch,
+			},
+		})
+		.promise();
+}

--- a/bandit/src/calculate-lambda/parse.ts
+++ b/bandit/src/calculate-lambda/parse.ts
@@ -1,37 +1,37 @@
-import type {GetQueryResultsOutput} from "aws-sdk/clients/athena";
-import { z } from 'zod';
-import {QueryReturnedInvalidDataError} from "../lib/errors";
+import type { GetQueryResultsOutput } from "aws-sdk/clients/athena";
+import { z } from "zod";
+import { QueryReturnedInvalidDataError } from "../lib/errors";
 
-const queryRowSchema = z.object({
+const variantQueryRowSchema = z.object({
 	testName: z.string(),
 	variantName: z.string(),
 	views: z.number(),
-	avGbp: z.number(),
+	avGbpPerView: z.number(),
 	acquisitions: z.number(),
 });
 
-export type QueryRow = z.infer<typeof queryRowSchema>;
+export type VariantQueryRow = z.infer<typeof variantQueryRowSchema>;
 
-const queryRowsSchema = z.array(queryRowSchema);
+const variantQueryRowsSchema = z.array(variantQueryRowSchema);
 
-export function parseResult(result: GetQueryResultsOutput): QueryRow[] {
+export function parseResult(result: GetQueryResultsOutput): VariantQueryRow[] {
 	const rows = (result.ResultSet?.Rows ?? []).slice(1);
 	const data = rows.map(({ Data: data }) => {
 		if (!data) {
 			return;
 		}
-		console.log({data})
+		console.log({ data });
 
 		return {
 			testName: data[0].VarCharValue,
 			variantName: data[1].VarCharValue,
-			views: parseInt(data[2].VarCharValue ?? ''),
-			avGbp: parseFloat(data[3].VarCharValue ?? ''),
-			acquisitions: parseInt(data[4].VarCharValue ?? ''),
+			views: parseInt(data[2].VarCharValue ?? ""),
+			avGbpPerView: parseFloat(data[3].VarCharValue ?? ""),
+			acquisitions: parseInt(data[4].VarCharValue ?? ""),
 		};
 	});
 
-	const parse = queryRowsSchema.safeParse(data);
+	const parse = variantQueryRowsSchema.safeParse(data);
 
 	if (!parse.success) {
 		console.log(parse.error);

--- a/bandit/src/query-lambda/local.ts
+++ b/bandit/src/query-lambda/local.ts
@@ -1,19 +1,20 @@
-import * as fs from 'fs';
-import * as dateFns from 'date-fns';
-import {run as runCalculate} from "../calculate-lambda/calculate-lambda";
-import {run as runQuery} from "./query-lambda";
+import * as fs from "fs";
+import * as dateFns from "date-fns";
+import { run as runCalculate } from "../calculate-lambda/calculate-lambda";
+import { run as runQuery } from "./query-lambda";
 
 const tests = [
 	{
-		name: '2024-03-05_EPIC_PRIMARY__US',
-		launchDate: '2024-03-15',
-		endDate: '2024-02-29'
-	}
-]
+		name: "2024-03-05_EPIC_PRIMARY__US",
+		launchDate: "2024-03-15",
+		endDate: "2024-02-29",
+	},
+];
 
-const wait = () => new Promise((resolve) => {
-	setTimeout(resolve, 5000);
-});
+const wait = () =>
+	new Promise((resolve) => {
+		setTimeout(resolve, 12000);
+	});
 
 // const meanStream = fs.createWriteStream('./means.csv', {flags: 'a'});
 
@@ -42,17 +43,17 @@ const wait = () => new Promise((resolve) => {
 // 	console.log(err);
 // });
 
-runQuery(tests, new Date('2024-03-15 10:00:00'))
-	.then(async result => {
+runQuery(tests, new Date("2024-03-20 10:00:00"))
+	.then(async (result) => {
 		await wait();
 		return result;
 	})
-	.then(result => {
+	.then((result) => {
 		return runCalculate(result);
 	})
-	.then(result => {
+	.then((result) => {
 		console.log(result);
 	})
-	.catch(err => {
+	.catch((err) => {
 		console.error(err);
 	});

--- a/cdk/lib/__snapshots__/bandit.test.ts.snap
+++ b/cdk/lib/__snapshots__/bandit.test.ts.snap
@@ -849,7 +849,7 @@ exports[`The Bandit stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"calculate-task":{"Next":"state-machine-success","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","Resource":"arn:",
+              "","Payload.$":"$"}},"calculate-task":{"Next":"state-machine-success","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["QueryPendingError"],"IntervalSeconds":10,"MaxAttempts":5}],"Type":"Task","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },

--- a/cdk/lib/bandit.ts
+++ b/cdk/lib/bandit.ts
@@ -1,7 +1,7 @@
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
-import { type App, RemovalPolicy } from 'aws-cdk-lib';
+import { type App, RemovalPolicy, Duration } from 'aws-cdk-lib';
 import { AttributeType, BillingMode, Table } from 'aws-cdk-lib/aws-dynamodb';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
@@ -89,7 +89,13 @@ export class Bandit extends GuStack {
 			definitionBody: DefinitionBody.fromChainable(
 				getBanditTestsTask
 					.next(queryTask)
-					.next(calculateTask)
+					.next(
+						calculateTask.addRetry({
+							errors: ['QueryPendingError'],
+							interval: Duration.seconds(10),
+							maxAttempts: 5,
+						}),
+					)
 					.next(new Succeed(this, 'state-machine-success')),
 			),
 		});

--- a/cdk/lib/bandit.ts
+++ b/cdk/lib/bandit.ts
@@ -1,7 +1,7 @@
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
-import { type App, RemovalPolicy, Duration } from 'aws-cdk-lib';
+import { type App, Duration, RemovalPolicy } from 'aws-cdk-lib';
 import { AttributeType, BillingMode, Table } from 'aws-cdk-lib/aws-dynamodb';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Creates the main body of the calculate lambda to write the results of the query lambda (previous function in state machine) to dynamo. At the moment it's not actually calculating anything...

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Run `AthenaOutputBucket=gu-support-analytics AWS_PROFILE=membership yarn local` - see results in dynamo table

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

