### PR TITLE
Bandit Dynamo - change partition key to `testName`

### DIFF
--- a/bandit/src/calculate-lambda/dynamo.ts
+++ b/bandit/src/calculate-lambda/dynamo.ts
@@ -11,7 +11,6 @@ interface VariantModel {
 export interface BanditModel {
 	testName: string;
 	variants: VariantModel[];
-	testNameWithAlgorithm: string;
 	timestamp: string;
 }
 
@@ -38,7 +37,6 @@ function buildDynamoRecord(
 	return {
 		testName,
 		variants,
-		testNameWithAlgorithm: `${testName}-epsilon-greedy`,
 		timestamp: new Date().toISOString(),
 	};
 }

--- a/cdk/lib/__snapshots__/bandit.test.ts.snap
+++ b/cdk/lib/__snapshots__/bandit.test.ts.snap
@@ -133,7 +133,7 @@ exports[`The Bandit stack matches the snapshot 1`] = `
       "Properties": {
         "AttributeDefinitions": [
           {
-            "AttributeName": "testNameWithAlgorithm",
+            "AttributeName": "testName",
             "AttributeType": "S",
           },
           {
@@ -144,7 +144,7 @@ exports[`The Bandit stack matches the snapshot 1`] = `
         "BillingMode": "PAY_PER_REQUEST",
         "KeySchema": [
           {
-            "AttributeName": "testNameWithAlgorithm",
+            "AttributeName": "testName",
             "KeyType": "HASH",
           },
           {

--- a/cdk/lib/bandit.ts
+++ b/cdk/lib/bandit.ts
@@ -87,7 +87,7 @@ export class Bandit extends GuStack {
 			removalPolicy: RemovalPolicy.RETAIN,
 			billingMode: BillingMode.PAY_PER_REQUEST,
 			partitionKey: {
-				name: 'testNameWithAlgorithm',
+				name: 'testName',
 				type: AttributeType.STRING,
 			},
 			sortKey: {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

After discussions we decided that the `support-bandit-` dynamo table should be algorithm agnostic and just record the latest AV / view data for each test, not for each test + algorithm. This means the partition key will be `testName` instead of `testNameWithAlgorithm` and requires a recreation of the stack and table

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Deploy to code, stack should recreate with dynamo table with new partition key.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
