### PR TITLE
Bandit - return the start time from query lambda and write in calculate lambda

### DIFF
--- a/bandit/src/calculate-lambda/calculate-lambda.ts
+++ b/bandit/src/calculate-lambda/calculate-lambda.ts
@@ -15,7 +15,11 @@ export async function run(events: QueryExecution[]): Promise<void> {
 			const executionId = event.executionId;
 			const result = await getCheckedExecutionResult(executionId, athena);
 			const rows = parseResult(result);
-			return buildWriteRequest(rows, event.testName, event.start);
+			return buildWriteRequest(
+				rows,
+				event.testName,
+				event.startTimestamp
+			);
 		})
 	);
 

--- a/bandit/src/calculate-lambda/calculate-lambda.ts
+++ b/bandit/src/calculate-lambda/calculate-lambda.ts
@@ -15,7 +15,7 @@ export async function run(events: QueryExecution[]): Promise<void> {
 			const executionId = event.executionId;
 			const result = await getCheckedExecutionResult(executionId, athena);
 			const rows = parseResult(result);
-			return buildWriteRequest(rows, event.testName);
+			return buildWriteRequest(rows, event.testName, event.start);
 		})
 	);
 

--- a/bandit/src/calculate-lambda/dynamo.ts
+++ b/bandit/src/calculate-lambda/dynamo.ts
@@ -11,33 +11,35 @@ interface VariantModel {
 export interface BanditModel {
 	testName: string;
 	variants: VariantModel[];
-	timestamp: string;
+	startTimestamp: string;
 }
 
 export function buildWriteRequest(
 	rows: VariantQueryRow[],
-	testName: string
+	testName: string,
+	start: Date
 ): DocumentClient.WriteRequest {
 	return {
 		PutRequest: {
-			Item: buildDynamoRecord(rows, testName),
+			Item: buildDynamoRecord(rows, testName, start),
 		},
 	};
 }
 
 function buildDynamoRecord(
 	rows: VariantQueryRow[],
-	testName: string
+	testName: string,
+	start: Date
 ): BanditModel {
-	const variants = rows.map((x) => ({
-		variantName: x.variantName,
-		avGbpPerView: x.avGbpPerView,
+	const variants = rows.map((row) => ({
+		variantName: row.variantName,
+		avGbpPerView: row.avGbpPerView,
 	}));
 
 	return {
 		testName,
 		variants,
-		timestamp: new Date().toISOString(),
+		startTimestamp: start.toISOString(),
 	};
 }
 

--- a/bandit/src/calculate-lambda/dynamo.ts
+++ b/bandit/src/calculate-lambda/dynamo.ts
@@ -11,7 +11,8 @@ interface VariantModel {
 export interface BanditModel {
 	testName: string;
 	variants: VariantModel[];
-	startTimestamp: string;
+	// the start of the interval
+	timestamp: string;
 }
 
 export function buildWriteRequest(
@@ -39,7 +40,7 @@ function buildDynamoRecord(
 	return {
 		testName,
 		variants,
-		startTimestamp: start.toISOString(),
+		timestamp: start.toISOString(),
 	};
 }
 

--- a/bandit/src/calculate-lambda/dynamo.ts
+++ b/bandit/src/calculate-lambda/dynamo.ts
@@ -18,11 +18,11 @@ export interface BanditModel {
 export function buildWriteRequest(
 	rows: VariantQueryRow[],
 	testName: string,
-	start: Date
+	startTimestamp: string
 ): DocumentClient.WriteRequest {
 	return {
 		PutRequest: {
-			Item: buildDynamoRecord(rows, testName, start),
+			Item: buildDynamoRecord(rows, testName, startTimestamp),
 		},
 	};
 }
@@ -30,7 +30,7 @@ export function buildWriteRequest(
 function buildDynamoRecord(
 	rows: VariantQueryRow[],
 	testName: string,
-	start: Date
+	startTimestamp: string
 ): BanditModel {
 	const variants = rows.map((row) => ({
 		variantName: row.variantName,
@@ -40,7 +40,7 @@ function buildDynamoRecord(
 	return {
 		testName,
 		variants,
-		timestamp: start.toISOString(),
+		timestamp: startTimestamp,
 	};
 }
 

--- a/bandit/src/lib/models.ts
+++ b/bandit/src/lib/models.ts
@@ -8,4 +8,5 @@ export interface Test {
 export interface QueryExecution {
 	executionId: QueryExecutionId;
 	testName: string;
+	start: Date;
 }

--- a/bandit/src/lib/models.ts
+++ b/bandit/src/lib/models.ts
@@ -8,5 +8,5 @@ export interface Test {
 export interface QueryExecution {
 	executionId: QueryExecutionId;
 	testName: string;
-	start: Date;
+	startTimestamp: string;
 }

--- a/bandit/src/query-lambda/queries.ts
+++ b/bandit/src/query-lambda/queries.ts
@@ -1,10 +1,13 @@
-import { format, set, subHours } from "date-fns";
+import { format } from "date-fns";
 import type { Test } from "../lib/models";
 import { Query } from "../lib/query";
 
-const buildQuery = (test: Test, stage: "CODE" | "PROD"): Query => {
-	const end = set(new Date(), { minutes: 0, seconds: 0, milliseconds: 0 });
-	const start = subHours(end, 1);
+const buildQuery = (
+	test: Test,
+	stage: "CODE" | "PROD",
+	start: Date,
+	end: Date
+): Query => {
 	const endTimestamp = end.toISOString().replace("T", " ");
 	const startTimestamp = start.toISOString().replace("T", " ");
 
@@ -46,5 +49,8 @@ const buildQuery = (test: Test, stage: "CODE" | "PROD"): Query => {
 
 export const getQueries = (
 	tests: Test[],
-	stage: "CODE" | "PROD"
-): Array<[Test, Query]> => tests.map((test) => [test, buildQuery(test, stage)]);
+	stage: "CODE" | "PROD",
+	start: Date,
+	end: Date
+): Array<[Test, Query]> =>
+	tests.map((test) => [test, buildQuery(test, stage, start, end)]);

--- a/bandit/src/query-lambda/query-lambda.ts
+++ b/bandit/src/query-lambda/query-lambda.ts
@@ -23,7 +23,11 @@ export async function run(tests: Test[]): Promise<QueryExecution[]> {
 	const results: Array<Promise<QueryExecution>> = queries.map(
 		([test, query]) =>
 			executeQuery(query, athenaOutputBucket, schemaName, athena).then(
-				(executionId) => ({ executionId, testName: test.name, start })
+				(executionId) => ({
+					executionId,
+					testName: test.name,
+					startTimestamp: start.toISOString(),
+				})
 			)
 	);
 

--- a/bandit/src/query-lambda/query-lambda.ts
+++ b/bandit/src/query-lambda/query-lambda.ts
@@ -1,4 +1,5 @@
 import * as AWS from "aws-sdk";
+import { set, subHours } from "date-fns";
 import type { QueryExecution, Test } from "../lib/models";
 import { executeQuery } from "../lib/query";
 import { getQueries } from "./queries";
@@ -14,12 +15,15 @@ export async function run(tests: Test[]): Promise<QueryExecution[]> {
 		return Promise.reject(`Invalid stage: ${stage ?? ""}`);
 	}
 
-	const queries = getQueries(tests, stage);
+	const end = set(new Date(), { minutes: 0, seconds: 0, milliseconds: 0 });
+	const start = subHours(end, 1);
+
+	const queries = getQueries(tests, stage, start, end);
 
 	const results: Array<Promise<QueryExecution>> = queries.map(
 		([test, query]) =>
 			executeQuery(query, athenaOutputBucket, schemaName, athena).then(
-				(executionId) => ({ executionId, testName: test.name })
+				(executionId) => ({ executionId, testName: test.name, start })
 			)
 	);
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds the start time of the interval being queried to the dynamo table `support-bandit-` to accurately show what the beginning of that time period was. In #326 we added precise intervals for the query, of duration one hour starting on the hour.

Before
![image](https://github.com/guardian/support-analytics/assets/114918544/cec183dc-13f5-4e0f-8966-7cff1bb7980c)

After
![image](https://github.com/guardian/support-analytics/assets/114918544/995bc36a-0db2-415d-8443-3bd437a388e9)


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
