### PR TITLE
Bandit - record views per variant

### DIFF
--- a/bandit/src/calculate-lambda/dynamo.ts
+++ b/bandit/src/calculate-lambda/dynamo.ts
@@ -6,6 +6,7 @@ import type { VariantQueryRow } from "./parse";
 interface VariantModel {
 	variantName: string;
 	avGbpPerView: number;
+	views: number;
 }
 
 export interface BanditModel {
@@ -35,6 +36,7 @@ function buildDynamoRecord(
 	const variants = rows.map((row) => ({
 		variantName: row.variantName,
 		avGbpPerView: row.avGbpPerView,
+		views: row.views,
 	}));
 
 	return {

--- a/bandit/src/calculate-lambda/dynamo.ts
+++ b/bandit/src/calculate-lambda/dynamo.ts
@@ -3,15 +3,16 @@ import type { DocumentClient } from "aws-sdk/clients/dynamodb";
 import type { PromiseResult } from "aws-sdk/lib/request";
 import type { VariantQueryRow } from "./parse";
 
-interface VariantModel {
+interface VariantSample {
 	variantName: string;
+	avGbp: number;
 	avGbpPerView: number;
 	views: number;
 }
 
-export interface BanditModel {
+export interface TestSample {
 	testName: string;
-	variants: VariantModel[];
+	variants: VariantSample[];
 	// the start of the interval
 	timestamp: string;
 }
@@ -32,9 +33,10 @@ function buildDynamoRecord(
 	rows: VariantQueryRow[],
 	testName: string,
 	startTimestamp: string
-): BanditModel {
+): TestSample {
 	const variants = rows.map((row) => ({
 		variantName: row.variantName,
+		avGbp: row.avGbp,
 		avGbpPerView: row.avGbpPerView,
 		views: row.views,
 	}));

--- a/bandit/src/calculate-lambda/parse.ts
+++ b/bandit/src/calculate-lambda/parse.ts
@@ -6,6 +6,7 @@ const variantQueryRowSchema = z.object({
 	testName: z.string(),
 	variantName: z.string(),
 	views: z.number(),
+	avGbp: z.number(),
 	avGbpPerView: z.number(),
 	acquisitions: z.number(),
 });
@@ -26,8 +27,9 @@ export function parseResult(result: GetQueryResultsOutput): VariantQueryRow[] {
 			testName: data[0].VarCharValue,
 			variantName: data[1].VarCharValue,
 			views: parseInt(data[2].VarCharValue ?? ""),
-			avGbpPerView: parseFloat(data[3].VarCharValue ?? ""),
-			acquisitions: parseInt(data[4].VarCharValue ?? ""),
+			avGbp: parseFloat(data[3].VarCharValue ?? ""),
+			avGbpPerView: parseFloat(data[4].VarCharValue ?? ""),
+			acquisitions: parseInt(data[5].VarCharValue ?? ""),
 		};
 	});
 

--- a/bandit/src/query-lambda/queries.ts
+++ b/bandit/src/query-lambda/queries.ts
@@ -38,6 +38,7 @@ const buildQuery = (
 		    test_name,
 			variant_name,
 			views,
+			av_gbp,
 			av_gbp / views,
 			acquisitions
 		FROM views


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Record each variant's views in the `support-bandit-` table, as this is the sample size of the AV/view so we need it if we want to calculate the overall mean.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
