### PR TITLE
Bandit: handle no acquisitions

### DIFF
--- a/bandit/src/query-lambda/queries.ts
+++ b/bandit/src/query-lambda/queries.ts
@@ -38,11 +38,11 @@ const buildQuery = (
 		    test_name,
 			variant_name,
 			views,
-			av_gbp,
-			av_gbp / views,
-			acquisitions
+			COALESCE(av_gbp, 0),
+			COALESCE(av_gbp, 0) / views,
+			COALESCE(acquisitions, 0)
 		FROM views
-		JOIN acquisitions USING (test_name, variant_name)
+		LEFT JOIN acquisitions USING (test_name, variant_name)
 	`;
 
 	return new Query(query, `query_${test.name}_${start.toISOString()}`);


### PR DESCRIPTION
It's possible for a variant to have some views but no acquisitions data. In this case we should default the acquisitions to 0 rather than null