### PR TITLE
Bandit: fix lambdas

### DIFF
--- a/bandit/src/calculate-lambda/calculate-lambda.ts
+++ b/bandit/src/calculate-lambda/calculate-lambda.ts
@@ -23,7 +23,11 @@ export async function run(events: QueryExecution[]): Promise<void> {
 		})
 	);
 
-	await writeBatch(batches, stage, docClient);
+	if (batches.length > 0) {
+		await writeBatch(batches, stage, docClient);
+	} else {
+		console.log("No data to write");
+	}
 
 	return;
 }

--- a/bandit/src/get-bandit-tests/get-bandit-tests.ts
+++ b/bandit/src/get-bandit-tests/get-bandit-tests.ts
@@ -1,12 +1,15 @@
 import * as AWS from "aws-sdk";
 import type { Test } from "../lib/models";
+import type { QueryLambdaInput } from "../query-lambda/query-lambda";
 import { queryChannelTests } from "./dynamo";
 
 const STAGE: string = process.env.STAGE ?? "PROD";
 
 const docClient = new AWS.DynamoDB.DocumentClient({ region: "eu-west-1" });
 
-export async function run(): Promise<Test[]> {
+export async function run(): Promise<QueryLambdaInput> {
 	const banditTests = await queryChannelTests(STAGE, docClient);
-	return banditTests.Items as Test[];
+	return {
+		tests: banditTests.Items as Test[],
+	};
 }

--- a/bandit/src/query-lambda/local.ts
+++ b/bandit/src/query-lambda/local.ts
@@ -13,7 +13,7 @@ const wait = () =>
 		setTimeout(resolve, 12000);
 	});
 
-runQuery(tests)
+runQuery({tests})
 	.then(async (result) => {
 		await wait();
 		return result;

--- a/bandit/src/query-lambda/query-lambda.ts
+++ b/bandit/src/query-lambda/query-lambda.ts
@@ -10,11 +10,12 @@ const stage = process.env.STAGE;
 const athenaOutputBucket = process.env.AthenaOutputBucket ?? "";
 const schemaName = "acquisition";
 
-export async function run(tests: Test[], date: Date = new Date()): Promise<QueryExecution[]> {
+export async function run(tests: Test[], inputDate?: Date): Promise<QueryExecution[]> {
 	if (stage !== "CODE" && stage !== "PROD") {
 		return Promise.reject(`Invalid stage: ${stage ?? ""}`);
 	}
 
+	const date = inputDate ?? new Date();
 	const end = set(date, { minutes: 0, seconds: 0, milliseconds: 0 });
 	const start = subHours(end, 1);
 

--- a/bandit/src/query-lambda/query-lambda.ts
+++ b/bandit/src/query-lambda/query-lambda.ts
@@ -10,21 +10,23 @@ const stage = process.env.STAGE;
 const athenaOutputBucket = process.env.AthenaOutputBucket ?? "";
 const schemaName = "acquisition";
 
-export async function run(tests: Test[], inputDate?: Date): Promise<QueryExecution[]> {
+interface QueryLambdaInput {
+	tests: Test[];
+	date?: Date;
+}
+
+export async function run(input: QueryLambdaInput): Promise<QueryExecution[]> {
 	if (stage !== "CODE" && stage !== "PROD") {
 		return Promise.reject(`Invalid stage: ${stage ?? ""}`);
 	}
 
-	console.log({inputDate});
-
-	const date = inputDate ?? new Date(Date.now());
-	console.log({date});
+	const date = input.date ?? new Date(Date.now());
 	const end = set(date, { minutes: 0, seconds: 0, milliseconds: 0 });
 	const start = subHours(end, 1);
 	console.log({start, end});
 	console.log(`start.toISOString(): ${start.toISOString()}`);
 
-	const queries = getQueries(tests, stage, start, end);
+	const queries = getQueries(input.tests, stage, start, end);
 
 	const results: Array<Promise<QueryExecution>> = queries.map(
 		([test, query]) =>

--- a/bandit/src/query-lambda/query-lambda.ts
+++ b/bandit/src/query-lambda/query-lambda.ts
@@ -15,9 +15,14 @@ export async function run(tests: Test[], inputDate?: Date): Promise<QueryExecuti
 		return Promise.reject(`Invalid stage: ${stage ?? ""}`);
 	}
 
+	console.log({inputDate});
+
 	const date = inputDate ?? new Date(Date.now());
+	console.log({date});
 	const end = set(date, { minutes: 0, seconds: 0, milliseconds: 0 });
 	const start = subHours(end, 1);
+	console.log({start, end});
+	console.log(`start.toISOString(): ${start.toISOString()}`);
 
 	const queries = getQueries(tests, stage, start, end);
 

--- a/bandit/src/query-lambda/query-lambda.ts
+++ b/bandit/src/query-lambda/query-lambda.ts
@@ -15,7 +15,7 @@ export async function run(tests: Test[], inputDate?: Date): Promise<QueryExecuti
 		return Promise.reject(`Invalid stage: ${stage ?? ""}`);
 	}
 
-	const date = inputDate ?? new Date();
+	const date = inputDate ?? new Date(Date.now());
 	const end = set(date, { minutes: 0, seconds: 0, milliseconds: 0 });
 	const start = subHours(end, 1);
 

--- a/bandit/src/query-lambda/query-lambda.ts
+++ b/bandit/src/query-lambda/query-lambda.ts
@@ -23,8 +23,6 @@ export async function run(input: QueryLambdaInput): Promise<QueryExecution[]> {
 	const date = input.date ?? new Date(Date.now());
 	const end = set(date, { minutes: 0, seconds: 0, milliseconds: 0 });
 	const start = subHours(end, 1);
-	console.log({start, end});
-	console.log(`start.toISOString(): ${start.toISOString()}`);
 
 	const queries = getQueries(input.tests, stage, start, end);
 

--- a/bandit/src/query-lambda/query-lambda.ts
+++ b/bandit/src/query-lambda/query-lambda.ts
@@ -10,7 +10,7 @@ const stage = process.env.STAGE;
 const athenaOutputBucket = process.env.AthenaOutputBucket ?? "";
 const schemaName = "acquisition";
 
-interface QueryLambdaInput {
+export interface QueryLambdaInput {
 	tests: Test[];
 	date?: Date;
 }

--- a/bandit/src/scripts/backfill.ts
+++ b/bandit/src/scripts/backfill.ts
@@ -45,7 +45,7 @@ const result = dates.reduce(
 	(prev, date) => {
 		return prev.then(() => {
 			console.log('Running for date', date);
-			return runQuery(tests, date)
+			return runQuery({tests, date})
 				.then((result) => {
 					return retry(() => runCalculate(result));
 				})


### PR DESCRIPTION
### Issue 1
If there are no batches to write then it fails with:
`"errorMessage": "1 validation error detected: Value '{support-bandit-CODE=[]}' at 'requestItems' failed to satisfy constraint: Map value must satisfy constraint: [Member must have length less than or equal to 25, Member must have length greater than or equal to 1]",`

### Issue 2
The query lambda takes a Date as the second parameter. This was introduced for the local backfill script, but actually broke the lambda in AWS because the second parameter will be some stuff that AWS passes in.