### PR TITLE
Bandit Query: use `stage` in query

### DIFF
--- a/bandit/src/query-lambda/queries.ts
+++ b/bandit/src/query-lambda/queries.ts
@@ -17,7 +17,7 @@ const buildQuery = (
 				ab.name test_name,
 				ab.variant variant_name,
 				COUNT(*) views
-			FROM acquisition.epic_views_prod, UNNEST(abtests) t(ab)
+			FROM acquisition.epic_views_${stage}, UNNEST(abtests) t(ab)
 			WHERE date_hour >= timestamp'${startTimestamp}' AND date_hour < timestamp'${endTimestamp}'
 			AND ab.name = '${test.name}'
 			GROUP BY 1,2
@@ -28,7 +28,7 @@ const buildQuery = (
 				ab.variant variant_name,
 				SUM(annualisedvaluegbp) av_gbp,
 				COUNT(*) acquisitions
-			FROM acquisition.acquisition_events_prod, UNNEST(abtests) t(ab)
+			FROM acquisition.acquisition_events_${stage}, UNNEST(abtests) t(ab)
 			WHERE acquisition_date >= date'${format(start, "yyyy-MM-dd")}'
 			AND timestamp >= timestamp'${startTimestamp}' AND timestamp < timestamp'${endTimestamp}'
 			AND ab.name = '${test.name}'


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Use the stage in the bandit query to get acquisition data, currently hardcoded to prod

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
