### PR TITLE
Bandit state machine - add scheduling rule

### DIFF
--- a/cdk/lib/__snapshots__/bandit.test.ts.snap
+++ b/cdk/lib/__snapshots__/bandit.test.ts.snap
@@ -1152,7 +1152,7 @@ exports[`The Bandit stack matches the snapshot 1`] = `
     "supportbanditStartupF0906432": {
       "Properties": {
         "Name": "support-bandit-startup-TEST",
-        "ScheduleExpression": "cron(0 * * * ? *)",
+        "ScheduleExpression": "cron(15 * * * ? *)",
         "State": "ENABLED",
         "Targets": [
           {

--- a/cdk/lib/__snapshots__/bandit.test.ts.snap
+++ b/cdk/lib/__snapshots__/bandit.test.ts.snap
@@ -954,6 +954,64 @@ exports[`The Bandit stack matches the snapshot 1`] = `
       "Type": "AWS::StepFunctions::StateMachine",
       "UpdateReplacePolicy": "Delete",
     },
+    "statemachineEventsRole4DAD46F3": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "events.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/support-analytics",
+          },
+          {
+            "Key": "Stack",
+            "Value": "deploy",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "statemachineEventsRoleDefaultPolicy317047D5": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "states:StartExecution",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "statemachine3BB5DA23",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "statemachineEventsRoleDefaultPolicy317047D5",
+        "Roles": [
+          {
+            "Ref": "statemachineEventsRole4DAD46F3",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "statemachineRole8DD785C2": {
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -1090,6 +1148,29 @@ exports[`The Bandit stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "supportbanditStartupF0906432": {
+      "Properties": {
+        "Name": "support-bandit-startup-TEST",
+        "ScheduleExpression": "cron(0 * * * ? *)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Ref": "statemachine3BB5DA23",
+            },
+            "Id": "Target0",
+            "Input": "{}",
+            "RoleArn": {
+              "Fn::GetAtt": [
+                "statemachineEventsRole4DAD46F3",
+                "Arn",
+              ],
+            },
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
     },
   },
 }

--- a/cdk/lib/bandit.ts
+++ b/cdk/lib/bandit.ts
@@ -157,7 +157,7 @@ export class Bandit extends GuStack {
 					input: RuleTargetInput.fromObject({}),
 				}),
 			],
-			schedule: Schedule.cron({ minute: '0' }),
+			schedule: Schedule.cron({ minute: '15' }),
 			ruleName: `${appName}-startup-${this.stage}`,
 		});
 	}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add a rule to schedule the state machine every hour on the hour

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Deploy to CODE, check that the state machine kicks off on the hour

![image](https://github.com/guardian/support-analytics/assets/114918544/7fedcdf7-75f1-490c-a2c1-50ac341f3c52)


<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->
