### PR TITLE
Bandit: cap annualised value at £250

### DIFF
--- a/bandit/src/query-lambda/queries.ts
+++ b/bandit/src/query-lambda/queries.ts
@@ -2,6 +2,8 @@ import { format } from "date-fns";
 import type { Test } from "../lib/models";
 import { Query } from "../lib/query";
 
+const ANNUALISED_VALUE_CAP_GBP = 250;
+
 const buildQuery = (
 	test: Test,
 	stage: "CODE" | "PROD",
@@ -26,7 +28,7 @@ const buildQuery = (
 			SELECT
 				ab.name test_name,
 				ab.variant variant_name,
-				SUM(annualisedvaluegbp) av_gbp,
+				SUM(IF(annualisedvaluegbp >= ${ANNUALISED_VALUE_CAP_GBP}, ${ANNUALISED_VALUE_CAP_GBP}, annualisedvaluegbp)) av_gbp,
 				COUNT(*) acquisitions
 			FROM acquisition.acquisition_events_prod, UNNEST(abtests) t(ab)
 			WHERE acquisition_date >= date'${format(start, "yyyy-MM-dd")}'


### PR DESCRIPTION
## What does this change?
Update query to exclude high-value acquisitions from the Bandit algorithm by capping Annualised Value at £250 per acquisition so that the data is more optimised in order to derive information from.

## How to test
We plucked out the acquisitions subquery from the query, amended it so that it included the if statement and used a value of 40 instead of 250:

```
SELECT
	annualisedvaluegbp av_gbp,
	IF(annualisedvaluegbp >= 40, 40, annualisedvaluegbp) capped_av_gbp
FROM acquisition.acquisition_events_prod, UNNEST(abtests) t(ab)
WHERE acquisition_date >= date'2024-04-17'
AND timestamp >= timestamp'2024-04-17 07:00:00' AND timestamp < timestamp'2024-04-25 07:00:00'
AND ab.name = '2024-02-09_MEGA_TOP_READER_EPIC__US'
```

We then ran it in Athena and verified that values over 40 were set to 40, and values of 40 and below remained as they were:

![image](https://github.com/guardian/support-analytics/assets/36296660/66619bd3-9721-4a9c-be10-f772a6eb886f)





