### PR TITLE
Use anonymised pageviews and filter on timestamp

### DIFF
--- a/bandit/src/query-lambda/bigquery.ts
+++ b/bandit/src/query-lambda/bigquery.ts
@@ -36,7 +36,9 @@ export const getDataForBanditTest = async (
 	const start = subHours(end, 1);
 	const testName = test.name;
 	const channel = test.channel;
-	const rows = await bigquery.query({query: buildQuery(test, 'PROD', start, end)});
+	const query = buildQuery(test, 'PROD', start, end);
+	console.log('Running query: ', query);
+	const rows = await bigquery.query({query});
 	//stage is hardcoded to PROD above as we don't have sufficient data for page views in the CODE tables to run the query successfully
 	return { testName,channel, rows };
 }

--- a/bandit/src/query-lambda/build-query.ts
+++ b/bandit/src/query-lambda/build-query.ts
@@ -119,9 +119,11 @@ views AS (
     ce.ab_test_name AS test_name,
     ce.ab_test_variant AS variant_name,
     COUNT(*) views
-  FROM datatech-platform-${stage.toLowerCase()}.online_traffic.fact_page_view
+  FROM datatech-platform-${stage.toLowerCase()}.online_traffic.fact_page_view_anonymised
   CROSS JOIN UNNEST(component_event_array) as ce
-  WHERE received_date = '${format(start, "yyyy-MM-dd")}'
+  -- Include previous day, as a pageview's received_date may be before midnight and a component_event after
+  WHERE received_date >= DATE_SUB('${format(start, "yyyy-MM-dd")}', INTERVAL 1 DAY) AND received_date <= '${format(start, "yyyy-MM-dd")}'
+  AND ce.event_timestamp >= '${startTimestamp}' AND ce.event_timestamp < '${endTimestamp}'
   AND ce.event_action = "VIEW"
   AND ce.component_type =  "${componentType}"
   AND ce.ab_test_name = '${test.name}'

--- a/bandit/src/query-lambda/query-lambda.ts
+++ b/bandit/src/query-lambda/query-lambda.ts
@@ -24,7 +24,11 @@ export async function run(input: QueryLambdaInput): Promise<void> {
 	const ssmPath = `/bandit-testing/${stage}/gcp-wif-credentials-config`;
 	const date = input.date ?? new Date(Date.now());
 	const end = set(date, { minutes: 0, seconds: 0, milliseconds: 0 });
-	const start = subHours(end, 1);
+	/**
+	 * Look back at the hour before last, to get a more complete set of events per hour.
+	 * This is because component_events can arrive in the pageview table late.
+	 */
+	const start = subHours(end, 2);
 	const startTimestamp = start.toISOString().replace("T", " ");
 	const client = await getSSMParam(ssmPath).then(buildAuthClient);
 

--- a/bandit/src/query-lambda/query-lambda.ts
+++ b/bandit/src/query-lambda/query-lambda.ts
@@ -38,6 +38,7 @@ export async function run(input: QueryLambdaInput): Promise<void> {
 
 	const writeRequests = resultsFromBigQuery.map(({testName,channel, rows}) => {
 		const parsed = parseResultFromBigQuery(rows);
+		console.log(`Writing row for ${testName}: `, parsed);
 		return buildWriteRequest(parsed, testName,channel, startTimestamp);
 	});
 	if (writeRequests.length > 0) {


### PR DESCRIPTION
The bandit query gets views + acquisitions for a specific 1-hour window.

This PR makes some changes:
1. uses `fact_page_view_anonymised`, as we should avoid using `fact_page_view`
2. adds a filter on event_timestamp for the specified hour - currently the query gets all `VIEW` events for the day
3. changes the query window to the hour _before_ last. This is because component_events can arrive in the pageview table a bit later, though the event_timestamp will be correct. So we get a more complete picture if we delay by an hour

E.g. log from running in CODE:
![Screenshot 2024-10-09 at 15 50 11](https://github.com/user-attachments/assets/03d836fc-1bdd-4c04-8533-98875722f36f)
