### PR TITLE
Use methodologies field in bandit

### DIFF
--- a/bandit/src/get-bandit-tests/dynamo.ts
+++ b/bandit/src/get-bandit-tests/dynamo.ts
@@ -13,10 +13,9 @@ const runQuery =(
 			ExpressionAttributeValues: {
 				":channel":channel,
 				":draft": "Draft",
-				":isBanditTest": true,
 			},
 			FilterExpression:
-				"#status <> :draft AND isBanditTest = :isBanditTest",
+				"#status <> :draft",
 		})
 		.promise();
 

--- a/bandit/src/get-bandit-tests/get-bandit-tests.ts
+++ b/bandit/src/get-bandit-tests/get-bandit-tests.ts
@@ -7,10 +7,13 @@ const STAGE: string = process.env.STAGE ?? "PROD";
 
 const docClient = new AWS.DynamoDB.DocumentClient({ region: "eu-west-1" });
 
+const filterBanditTests = (tests: Test[]): Test[] =>
+	tests.filter(test => !!test.methodologies?.find((method) => method.name === 'EpsilonGreedyBandit'));
+
 export async function run(): Promise<QueryLambdaInput> {
-	const banditTests = await queryChannelTests(STAGE, docClient);
-	const tests = banditTests.flatMap(test => test.Items ?? []);
+	const tests = (await queryChannelTests(STAGE, docClient)).flatMap(test => test.Items ?? []) as Test[];
+	const banditTests = filterBanditTests(tests);
 	return {
-		 tests: tests as Test[],
+		 tests: banditTests,
 	};
 }

--- a/bandit/src/lib/models.ts
+++ b/bandit/src/lib/models.ts
@@ -1,4 +1,14 @@
+interface ABTestMethodology {
+	name: 'ABTest';
+}
+interface EpsilonGreedyBanditMethodology {
+	name: 'EpsilonGreedyBandit';
+	epsilon: number;
+}
+export type Methodology = ABTestMethodology | EpsilonGreedyBanditMethodology;
+
 export interface Test {
 	name: string;
 	channel: string;
+	methodologies?: Methodology[];
 }


### PR DESCRIPTION
We're migrating to a new way of modelling bandit tests: https://github.com/guardian/support-admin-console/pull/640/files#diff-805e9a8dadac4c5cc4074591de0677066ad2562f7455fa761b76db91e66f20fdR40
The `isBanditTest` field is being removed.

With this change we now fetch all live channel tests, and filter for bandit tests using the `methodologies` field.
This is because Dynamodb's filter expressions do not support the type of filtering we need here.