### PR TITLE
Remove spaces from bandit test name

### DIFF
--- a/bandit/src/query-lambda/dynamo.ts
+++ b/bandit/src/query-lambda/dynamo.ts
@@ -44,7 +44,7 @@ function buildDynamoRecord(
 	}));
 
 	return {
-		testName: channel+ " _ "+ testName,
+		testName: channel + "_" + testName,
 		variants,
 		timestamp: startTimestamp,
 	};


### PR DESCRIPTION
In the bandit data table we prefix the test name with the channel name, e.g.
`Epic_my-test`
This is because this field is the partition key and we want to avoid potential name clashes between epics + banners.
Currently there are spaces in the string, which isn't right