### PR TITLE
Use correct date in bandit

### DIFF
--- a/bandit/src/query-lambda/bigquery.ts
+++ b/bandit/src/query-lambda/bigquery.ts
@@ -1,6 +1,6 @@
 import type { SimpleQueryRowsResponse} from "@google-cloud/bigquery";
 import {BigQuery} from "@google-cloud/bigquery";
-import {set, subHours} from "date-fns";
+import {set, addHours} from "date-fns";
 import type { BaseExternalAccountClient, ExternalAccountClientOptions } from 'google-auth-library';
 import { ExternalAccountClient } from 'google-auth-library';
 import type {Test} from "../lib/models";
@@ -25,15 +25,14 @@ export const getDataForBanditTest = async (
 	authClient: BaseExternalAccountClient,
 	stage: 'CODE' | 'PROD',
 	test: Test,
-	date: Date = new Date(Date.now()),
+	start: Date,
 ): Promise<BigQueryResult> => {
 	const bigquery = new BigQuery({
 		projectId: `datatech-platform-${stage.toLowerCase()}`,
 		authClient,
 	});
 
-	const end = set(date, { minutes: 0, seconds: 0, milliseconds: 0 });
-	const start = subHours(end, 1);
+	const end = addHours(start, 1);
 	const testName = test.name;
 	const channel = test.channel;
 	const query = buildQuery(test, 'PROD', start, end);

--- a/bandit/src/query-lambda/bigquery.ts
+++ b/bandit/src/query-lambda/bigquery.ts
@@ -1,6 +1,6 @@
 import type { SimpleQueryRowsResponse} from "@google-cloud/bigquery";
 import {BigQuery} from "@google-cloud/bigquery";
-import {set, addHours} from "date-fns";
+import {addHours} from "date-fns";
 import type { BaseExternalAccountClient, ExternalAccountClientOptions } from 'google-auth-library';
 import { ExternalAccountClient } from 'google-auth-library';
 import type {Test} from "../lib/models";

--- a/bandit/src/query-lambda/query-lambda.ts
+++ b/bandit/src/query-lambda/query-lambda.ts
@@ -23,12 +23,12 @@ export async function run(input: QueryLambdaInput): Promise<void> {
 
 	const ssmPath = `/bandit-testing/${stage}/gcp-wif-credentials-config`;
 	const date = input.date ?? new Date(Date.now());
-	const end = set(date, { minutes: 0, seconds: 0, milliseconds: 0 });
+	const currentHour = set(date, { minutes: 0, seconds: 0, milliseconds: 0 });
 	/**
 	 * Look back at the hour before last, to get a more complete set of events per hour.
 	 * This is because component_events can arrive in the pageview table late.
 	 */
-	const start = subHours(end, 2);
+	const start = subHours(currentHour, 2);
 	const startTimestamp = start.toISOString().replace("T", " ");
 	const client = await getSSMParam(ssmPath).then(buildAuthClient);
 

--- a/bandit/src/query-lambda/query-lambda.ts
+++ b/bandit/src/query-lambda/query-lambda.ts
@@ -33,7 +33,7 @@ export async function run(input: QueryLambdaInput): Promise<void> {
 	const client = await getSSMParam(ssmPath).then(buildAuthClient);
 
 	const resultsFromBigQuery: BigQueryResult[] = await Promise.all(
-		input.tests.map(test => getDataForBanditTest(client, stage, test, input.date))
+		input.tests.map(test => getDataForBanditTest(client, stage, test, start))
 	);
 
 	const writeRequests = resultsFromBigQuery.map(({testName,channel, rows}) => {


### PR DESCRIPTION
Currently it uses the current time, but we should be using `start`, which is current time minus 2 hours.
I've also removed some date logic from `getDataForBanditTest`. We now just pass in the start time, and it queries for 1 hour of data from then.