### PR TITLE
Fix the schedule for the super mode lambda

### DIFF
--- a/cdk/lib/__snapshots__/super-mode-calculator.test.ts.snap
+++ b/cdk/lib/__snapshots__/super-mode-calculator.test.ts.snap
@@ -4,7 +4,6 @@ exports[`The SuperModeCalculator stack matches the snapshot 1`] = `
 {
   "Metadata": {
     "gu:cdk:constructs": [
-      "GuStringParameter",
       "GuDistributionBucketParameter",
       "GuScheduledLambda",
     ],
@@ -15,15 +14,6 @@ exports[`The SuperModeCalculator stack matches the snapshot 1`] = `
       "Default": "/account/services/artifact.bucket",
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
-    },
-    "ScheduleState": {
-      "AllowedValues": [
-        "ENABLED",
-        "DISABLED",
-      ],
-      "Default": "ENABLED",
-      "Description": "The state of the schedule",
-      "Type": "String",
     },
   },
   "Resources": {
@@ -81,6 +71,43 @@ exports[`The SuperModeCalculator stack matches the snapshot 1`] = `
         "Timeout": 30,
       },
       "Type": "AWS::Lambda::Function",
+    },
+    "SuperModeCalculatorSuperModeCalculatorrate1hour07DE85BC7": {
+      "Properties": {
+        "ScheduleExpression": "rate(1 hour)",
+        "State": "ENABLED",
+        "Targets": [
+          {
+            "Arn": {
+              "Fn::GetAtt": [
+                "SuperModeCalculatorC30EED85",
+                "Arn",
+              ],
+            },
+            "Id": "Target0",
+          },
+        ],
+      },
+      "Type": "AWS::Events::Rule",
+    },
+    "SuperModeCalculatorSuperModeCalculatorrate1hour0AllowEventRuleSuperModeCalculatorED95104E7D359CFF": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "SuperModeCalculatorC30EED85",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "SuperModeCalculatorSuperModeCalculatorrate1hour07DE85BC7",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
     },
     "querylambdaroleC6C8A94B": {
       "Properties": {

--- a/cdk/lib/super-mode-calculator.ts
+++ b/cdk/lib/super-mode-calculator.ts
@@ -1,6 +1,6 @@
 import {GuScheduledLambda} from "@guardian/cdk";
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
-import {GuStack, GuStringParameter} from '@guardian/cdk/lib/constructs/core';
+import { GuStack } from '@guardian/cdk/lib/constructs/core';
 import {type App, Duration, RemovalPolicy} from 'aws-cdk-lib';
 import {AttributeType, BillingMode, ProjectionType, Table} from "aws-cdk-lib/aws-dynamodb";
 import { Schedule } from 'aws-cdk-lib/aws-events';
@@ -12,20 +12,11 @@ export class SuperModeCalculator extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
 		super(scope, id, props);
 
-		const scheduleState = new GuStringParameter(this, 'ScheduleState', {
-			description: 'The state of the schedule',
-			default: 'ENABLED',
-			allowedValues: ['ENABLED', 'DISABLED'],
-		});
-
-		const scheduleRules =
-			scheduleState.valueAsString === 'ENABLED'
-				? [
+		const scheduleRules = [
 					{
 						schedule: Schedule.rate(Duration.minutes(60)),
 					},
 				]
-				: [];
 
 		const superModeCalculatorTable = new Table(this, 'super-mode-calculator-table', {
 			tableName: `super-mode-calculator-${this.stage}`,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The new lambda for Super mode querying BigQuery has no AWS::Events::Rule added in the cloudformation .Hence it has no triggers.This is to fix that

## How to test
Tested in CODE

## Before the change 
<img width="1207" alt="image" src="https://github.com/user-attachments/assets/cbf228d5-a864-4248-b3f5-23e1c591a068">


## After the change 
<img width="1207" alt="image" src="https://github.com/user-attachments/assets/2623f5d1-8389-4e30-87a6-c62bc8d16044">
 

support-super-mode-CODE-SuperModeCalculatorSuperMod-yZlV05XBs8a2  Rule was created in [Amazon EventBridge](https://eu-west-1.console.aws.amazon.com/events/home?region=eu-west-1#)
