### PR TITLE
Use methodology test names

### DIFF
--- a/bandit/src/lib/models.ts
+++ b/bandit/src/lib/models.ts
@@ -5,10 +5,19 @@ interface EpsilonGreedyBanditMethodology {
 	name: 'EpsilonGreedyBandit';
 	epsilon: number;
 }
-export type Methodology = ABTestMethodology | EpsilonGreedyBanditMethodology;
+// each methodology may have an optional testName, which should be used for tracking
+export type Methodology = { testName?: string } & (
+	| ABTestMethodology
+	| EpsilonGreedyBanditMethodology
+);
 
 export interface Test {
 	name: string;
 	channel: string;
 	methodologies?: Methodology[];
+}
+
+export interface BanditTestConfig {
+	name: string; // this may be specific to the methodology, e.g. MY_TEST_EpsilonGreedyBandit-0.5
+	channel: string;
 }

--- a/bandit/src/query-lambda/bigquery.ts
+++ b/bandit/src/query-lambda/bigquery.ts
@@ -3,7 +3,7 @@ import {BigQuery} from "@google-cloud/bigquery";
 import {addHours} from "date-fns";
 import type { BaseExternalAccountClient, ExternalAccountClientOptions } from 'google-auth-library';
 import { ExternalAccountClient } from 'google-auth-library';
-import type {Test} from "../lib/models";
+import type {BanditTestConfig} from "../lib/models";
 import {buildQuery} from "./build-query";
 
 export const buildAuthClient = (clientConfig: string): Promise<BaseExternalAccountClient> => new Promise((resolve, reject) => {
@@ -16,15 +16,16 @@ export const buildAuthClient = (clientConfig: string): Promise<BaseExternalAccou
 	}
 });
 
-export interface BigQueryResult{
+export interface BigQueryResult {
 	testName: string;
 	channel: string;
 	rows: SimpleQueryRowsResponse;
 }
+
 export const getDataForBanditTest = async (
 	authClient: BaseExternalAccountClient,
 	stage: 'CODE' | 'PROD',
-	test: Test,
+	test: BanditTestConfig,
 	start: Date,
 ): Promise<BigQueryResult> => {
 	const bigquery = new BigQuery({

--- a/bandit/src/query-lambda/build-query.ts
+++ b/bandit/src/query-lambda/build-query.ts
@@ -1,9 +1,9 @@
 import {format, subDays} from "date-fns";
-import type {Test} from "../lib/models";
+import type {BanditTestConfig} from "../lib/models";
 
 const ANNUALISED_VALUE_CAP = 250;
 export const buildQuery = (
-	test: Test,
+	test: BanditTestConfig,
 	stage: "CODE" | "PROD",
 	start: Date,
 	end: Date,


### PR DESCRIPTION
A [recent change](https://github.com/guardian/support-dotcom-components/pull/1251) added an optional `testName` field to the `Methodology` model.
This is so that we can compare different methodologies with the same message test.

The bandit data system now needs to query for each bandit methodology in a message test, using this `testName` field.