### PR TITLE
Add Roulette to the bandit system

### DIFF
--- a/bandit/src/get-bandit-tests/get-bandit-tests.ts
+++ b/bandit/src/get-bandit-tests/get-bandit-tests.ts
@@ -8,7 +8,7 @@ const STAGE: string = process.env.STAGE ?? "PROD";
 const docClient = new AWS.DynamoDB.DocumentClient({ region: "eu-west-1" });
 
 const filterBanditTests = (tests: Test[]): Test[] =>
-	tests.filter(test => !!test.methodologies?.find((method) => method.name === 'EpsilonGreedyBandit'));
+	tests.filter(test => !!test.methodologies?.find((method) => method.name === 'EpsilonGreedyBandit'|| method.name === 'Roulette'));
 
 export async function run(): Promise<QueryLambdaInput> {
 	const tests = (await queryChannelTests(STAGE, docClient)).flatMap(test => test.Items ?? []) as Test[];

--- a/bandit/src/lib/models.ts
+++ b/bandit/src/lib/models.ts
@@ -5,10 +5,14 @@ interface EpsilonGreedyBanditMethodology {
 	name: 'EpsilonGreedyBandit';
 	epsilon: number;
 }
+interface RouletteMethodology {
+	name: 'Roulette';
+}
 // each methodology may have an optional testName, which should be used for tracking
 export type Methodology = { testName?: string } & (
 	| ABTestMethodology
 	| EpsilonGreedyBanditMethodology
+	| RouletteMethodology
 );
 
 export interface Test {

--- a/bandit/src/query-lambda/query-lambda.ts
+++ b/bandit/src/query-lambda/query-lambda.ts
@@ -19,7 +19,7 @@ export interface QueryLambdaInput {
 // Each test may contain 1 or more bandit methodologies
 const getTestConfigs = (test: Test): BanditTestConfig[] => {
 	const bandits: Methodology[] = (test.methodologies ?? []).filter(
-		(method) => method.name === 'EpsilonGreedyBandit',
+		(method) => method.name === 'EpsilonGreedyBandit'|| method.name === 'Roulette',
 	);
 	return bandits.map((method) => ({
 		name: method.testName ?? test.name, // if the methodology should be tracked with a different name then use that


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR has changes to filter out tests marked with Roulette selection method as bandit tests and thus populate the relevant bandit data for the Roulette tests

## Images

