### PR TITLE
Add alarms for bandit step function

### DIFF
--- a/cdk/lib/__snapshots__/bandit.test.ts.snap
+++ b/cdk/lib/__snapshots__/bandit.test.ts.snap
@@ -116,6 +116,8 @@ exports[`The Bandit stack matches the snapshot 1`] = `
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
       "GuLambdaFunction",
+      "GuAlarm",
+      "GuAlarm",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -127,6 +129,102 @@ exports[`The Bandit stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
+    "ExecutionFailureAlarm65D8EF83": {
+      "DependsOn": [
+        "statemachineEventsRoleDefaultPolicy317047D5",
+        "statemachineEventsRole4DAD46F3",
+        "statemachine3BB5DA23",
+        "statemachineRoleDefaultPolicyDBF71609",
+        "statemachineRole8DD785C2",
+      ],
+      "Properties": {
+        "ActionsEnabled": false,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-TEST",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "There was a failure whilst setting up support bandit data . Check https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/statemachines/view/arn%3Aaws%3Astates%3Aeu-west-1%3A865473395570%3AstateMachine%3Asupport-bandit-TEST?statusFilter=FAILED",
+        "AlarmName": " Execution Failure in Support Bandit TEST.",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "StateMachineArn",
+            "Value": {
+              "Ref": "statemachine3BB5DA23",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ExecutionsFailed",
+        "Namespace": "AWS/States",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "TimeoutAlarm4022815E": {
+      "DependsOn": [
+        "statemachineEventsRoleDefaultPolicy317047D5",
+        "statemachineEventsRole4DAD46F3",
+        "statemachine3BB5DA23",
+        "statemachineRoleDefaultPolicyDBF71609",
+        "statemachineRole8DD785C2",
+      ],
+      "Properties": {
+        "ActionsEnabled": false,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":alarms-handler-topic-TEST",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "There was a timeout whilst setting up bandit data. Check https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/statemachines/view/arn%3Aaws%3Astates%3Aeu-west-1%3A865473395570%3AstateMachine%3Asupport-bandit-TEST?statusFilter=TIMED_OUT",
+        "AlarmName": "Support Bandit Timeout in TEST.",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "StateMachineArn",
+            "Value": {
+              "Ref": "statemachine3BB5DA23",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "ExecutionsTimedOut",
+        "Namespace": "AWS/States",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
     "banditstableFE34CD9A": {
       "DeletionPolicy": "Retain",
       "Properties": {

--- a/cdk/lib/__snapshots__/bandit.test.ts.snap
+++ b/cdk/lib/__snapshots__/bandit.test.ts.snap
@@ -158,7 +158,7 @@ exports[`The Bandit stack matches the snapshot 1`] = `
           },
         ],
         "AlarmDescription": "There was a failure whilst setting up support bandit data . Check https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/statemachines/view/arn%3Aaws%3Astates%3Aeu-west-1%3A865473395570%3AstateMachine%3Asupport-bandit-TEST?statusFilter=FAILED",
-        "AlarmName": " Execution Failure in Support Bandit TEST.",
+        "AlarmName": "Execution Failure in Support Bandit TEST.",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {

--- a/cdk/lib/bandit.ts
+++ b/cdk/lib/bandit.ts
@@ -187,7 +187,7 @@ export class Bandit extends GuStack {
 			app: appName,
 			actionsEnabled: isProd,
 			snsTopicName: `alarms-handler-topic-${this.stage}`,
-			alarmName: ` Execution Failure in Support Bandit ${this.stage}.`,
+			alarmName: `Execution Failure in Support Bandit ${this.stage}.`,
 			alarmDescription: `There was a failure whilst setting up support bandit data . Check https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/statemachines/view/arn%3Aaws%3Astates%3Aeu-west-1%3A865473395570%3AstateMachine%3Asupport-bandit-${this.stage}?statusFilter=FAILED`,
 			metric: new Metric({
 				metricName: "ExecutionsFailed",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

Co-authored by : @charleycampbell 

## What does this change?
We recently discovered a bug in the Bandit data caused by duplicate test names being copied within the RRCP. This issue will be fixed as part of [this PR](https://github.com/guardian/support-admin-console/pull/670).

This PR introduces failure and timeout alarms for Bandit data. If either alarm is triggered, the Growth team will be notified in their alarms channel (which is[ configured here](https://github.com/guardian/support-service-lambdas/pull/2631))..

Testing
To verify these changes, we:

Built the new snapshot and deployed it to the code environment.
Triggered the Lambda step function to build, which failed due to duplicate test names (see first screenshot).
Confirmed that the alarm successfully notified the Growth team in their alarms channel (see second screenshot).

Failing step function
<img width="840" alt="image" src="https://github.com/user-attachments/assets/b3f14706-d4c7-47b7-8984-10d907cda2df" />

Alarm in Growth Alarms channel
<img width="668" alt="image" src="https://github.com/user-attachments/assets/54c79c79-1794-4138-8eab-1552afaa6db9" />

