### PR TITLE
Add totalAcquisitions to super-mode data

### DIFF
--- a/super-mode-calculator/src/lib/build-query.ts
+++ b/super-mode-calculator/src/lib/build-query.ts
@@ -116,6 +116,7 @@ views AS (
 SELECT acquisitions_agg.referrer_url AS url,
 	   acquisitions_agg.region,
 	   acquisitions_agg.sum_av_gbp AS totalAv,
+	   acquisitions_agg.acquisitions AS totalAcquisitions,
 	   views.total_views AS totalViews,
 	   acquisitions_agg.sum_av_gbp / views.total_views AS avPerView
 	FROM acquisitions_agg

--- a/super-mode-calculator/src/parse.ts
+++ b/super-mode-calculator/src/parse.ts
@@ -10,6 +10,7 @@ export interface QueryRow {
 	totalAv: number;
 	totalViews: number;
 	avPerView: number;
+	totalAcquisitions: number;
 }
 
 const regionSchema = z.union([
@@ -28,6 +29,7 @@ const queryRowSchema = z.object({
 	totalAv: z.number(),
 	totalViews: z.number(),
 	avPerView: z.number(),
+	totalAcquisitions: z.number(),
 });
 
 const queryRowsSchema = z.array(queryRowSchema);


### PR DESCRIPTION
Adds the total acquisitions count to the super mode dynamodb table.
It would be useful to show this in the super mode dashboard.