### PR TITLE
Retry bandit query lambda

### DIFF
--- a/cdk/lib/__snapshots__/bandit.test.ts.snap
+++ b/cdk/lib/__snapshots__/bandit.test.ts.snap
@@ -786,7 +786,7 @@ exports[`The Bandit stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"query-task":{"Next":"state-machine-success","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":120,"MaxAttempts":5}],"Type":"Task","InputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"query-task":{"Next":"state-machine-success","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":120,"MaxAttempts":5,"BackoffRate":2}],"Type":"Task","InputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },

--- a/cdk/lib/__snapshots__/bandit.test.ts.snap
+++ b/cdk/lib/__snapshots__/bandit.test.ts.snap
@@ -786,7 +786,7 @@ exports[`The Bandit stack matches the snapshot 1`] = `
                   "Arn",
                 ],
               },
-              "","Payload.$":"$"}},"query-task":{"Next":"state-machine-success","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2}],"Type":"Task","InputPath":"$.Payload","Resource":"arn:",
+              "","Payload.$":"$"}},"query-task":{"Next":"state-machine-success","Retry":[{"ErrorEquals":["Lambda.ClientExecutionTimeoutException","Lambda.ServiceException","Lambda.AWSLambdaException","Lambda.SdkClientException"],"IntervalSeconds":2,"MaxAttempts":6,"BackoffRate":2},{"ErrorEquals":["States.ALL"],"IntervalSeconds":120,"MaxAttempts":5}],"Type":"Task","InputPath":"$.Payload","Resource":"arn:",
               {
                 "Ref": "AWS::Partition",
               },

--- a/cdk/lib/bandit.ts
+++ b/cdk/lib/bandit.ts
@@ -153,6 +153,7 @@ export class Bandit extends GuStack {
 							errors: [Errors.ALL],
 							interval: Duration.minutes(2),
 							maxAttempts: 5,
+							backoffRate: 2,
 						}),
 					)
 					.next(new Succeed(this, 'state-machine-success')),

--- a/cdk/lib/bandit.ts
+++ b/cdk/lib/bandit.ts
@@ -15,7 +15,8 @@ import {
 } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import {
-	DefinitionBody, Errors,
+	DefinitionBody,
+	Errors,
 	StateMachine,
 	Succeed,
 } from 'aws-cdk-lib/aws-stepfunctions';

--- a/cdk/lib/bandit.ts
+++ b/cdk/lib/bandit.ts
@@ -15,7 +15,7 @@ import {
 } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import {
-	DefinitionBody,
+	DefinitionBody, Errors,
 	StateMachine,
 	Succeed,
 } from 'aws-cdk-lib/aws-stepfunctions';
@@ -147,7 +147,13 @@ export class Bandit extends GuStack {
 			stateMachineName: `${appName}-${this.stage}`,
 			definitionBody: DefinitionBody.fromChainable(
 				getBanditTestsTask
-					.next(queryTask)
+					.next(
+						queryTask.addRetry({
+							errors: [Errors.ALL],
+							interval: Duration.minutes(2),
+							maxAttempts: 5,
+						}),
+					)
 					.next(new Succeed(this, 'state-machine-success')),
 			),
 		});


### PR DESCRIPTION
We've seen the bandit data state machine fail when the query lambda times out. This is presumably because of an issue connecting to BigQuery.
This PR updates the state machine to retry this lambda 5 times. The state machine runs hourly, so it's not urgent that it succeeds quickly.

Tested in CODE by:
1. deploying the branch to CODE
2. manually changing the lambda timeout to 2 seconds (too short)
3. starting a new state machine execution and waiting for it to fail a couple of times
4. manually changing the lambda timeout back to 1 minute
5. waiting for it to succeed
<img width="713" alt="Screenshot 2025-02-03 at 15 34 54" src="https://github.com/user-attachments/assets/bfd34c3b-54c3-4c86-b8af-dcdc132298b8" />
