### PR TITLE
Remove athena permissions

### DIFF
--- a/cdk/lib/__snapshots__/bandit.test.ts.snap
+++ b/cdk/lib/__snapshots__/bandit.test.ts.snap
@@ -518,7 +518,6 @@ exports[`The Bandit stack matches the snapshot 1`] = `
         "Environment": {
           "Variables": {
             "APP": "support-bandit",
-            "AthenaOutputBucket": "gu-support-analytics",
             "STACK": "deploy",
             "STAGE": "TEST",
           },
@@ -573,20 +572,6 @@ exports[`The Bandit stack matches the snapshot 1`] = `
           ],
           "Version": "2012-10-17",
         },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/AmazonAthenaFullAccess",
-              ],
-            ],
-          },
-        ],
         "RoleName": "bandit-query-TEST",
         "Tags": [
           {
@@ -641,22 +626,6 @@ exports[`The Bandit stack matches the snapshot 1`] = `
                   ],
                 ],
               },
-            },
-            {
-              "Action": "s3:*",
-              "Effect": "Allow",
-              "Resource": [
-                "arn:aws:s3:::gu-support-analytics/*",
-                "arn:aws:s3:::gu-support-analytics",
-              ],
-            },
-            {
-              "Action": "s3:*",
-              "Effect": "Allow",
-              "Resource": [
-                "arn:aws:s3:::acquisition-events/*",
-                "arn:aws:s3:::acquisition-events",
-              ],
             },
             {
               "Action": "dynamodb:BatchWriteItem",

--- a/cdk/lib/bandit.ts
+++ b/cdk/lib/bandit.ts
@@ -7,12 +7,7 @@ import { ComparisonOperator, Metric } from 'aws-cdk-lib/aws-cloudwatch';
 import { AttributeType, BillingMode, Table } from 'aws-cdk-lib/aws-dynamodb';
 import { Rule, RuleTargetInput, Schedule } from 'aws-cdk-lib/aws-events';
 import { SfnStateMachine } from 'aws-cdk-lib/aws-events-targets';
-import {
-	ManagedPolicy,
-	PolicyStatement,
-	Role,
-	ServicePrincipal,
-} from 'aws-cdk-lib/aws-iam';
+import { PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import {
 	DefinitionBody,
@@ -96,34 +91,12 @@ export class Bandit extends GuStack {
 				],
 			}),
 		);
-		queryLambdaRole.addToPolicy(
-			new PolicyStatement({
-				actions: ['s3:*'],
-				resources: [
-					`arn:aws:s3:::gu-support-analytics/*`,
-					`arn:aws:s3:::gu-support-analytics`,
-				],
-			}),
-		);
-		queryLambdaRole.addToPolicy(
-			new PolicyStatement({
-				actions: ['s3:*'],
-				resources: [
-					`arn:aws:s3:::acquisition-events/*`,
-					`arn:aws:s3:::acquisition-events`,
-				],
-			}),
-		);
 
 		queryLambdaRole.addToPolicy(
 			new PolicyStatement({
 				actions: ['dynamodb:BatchWriteItem'],
 				resources: [banditsTable.tableArn],
 			}),
-		);
-
-		queryLambdaRole.addManagedPolicy(
-			ManagedPolicy.fromAwsManagedPolicyName('AmazonAthenaFullAccess'),
 		);
 
 		const queryLambda = new GuLambdaFunction(this, 'query-lambda', {
@@ -133,9 +106,6 @@ export class Bandit extends GuStack {
 			handler: 'query-lambda/query-lambda.run',
 			fileName: `${appName}.zip`,
 			timeout: Duration.seconds(60),
-			environment: {
-				AthenaOutputBucket: 'gu-support-analytics',
-			},
 			role: queryLambdaRole,
 		});
 


### PR DESCRIPTION
This system originally used Athena + S3 for its data.
But it now uses BigQuery.
This PR removes some old permissions that are no longer needed since the BigQuery migration