### PR TITLE
Change bandit schedule to 45mins past

### DIFF
--- a/cdk/lib/__snapshots__/bandit.test.ts.snap
+++ b/cdk/lib/__snapshots__/bandit.test.ts.snap
@@ -896,7 +896,7 @@ exports[`The Bandit stack matches the snapshot 1`] = `
     "supportbanditStartupF0906432": {
       "Properties": {
         "Name": "support-bandit-startup-TEST",
-        "ScheduleExpression": "cron(15 * * * ? *)",
+        "ScheduleExpression": "cron(45 * * * ? *)",
         "State": "ENABLED",
         "Targets": [
           {

--- a/cdk/lib/bandit.ts
+++ b/cdk/lib/bandit.ts
@@ -141,7 +141,7 @@ export class Bandit extends GuStack {
 					input: RuleTargetInput.fromObject({}),
 				}),
 			],
-			schedule: Schedule.cron({ minute: '15' }),
+			schedule: Schedule.cron({ minute: '45' }),
 			ruleName: `${appName}-startup-${this.stage}`,
 		});
 		// Alarms


### PR DESCRIPTION
The support-bandit state machine runs hourly to produce samples for the multi-armed bandit algorithms in SDC.
It queries the hourly pageview data in BigQuery.
Currently it runs at 15mins past the hour, every hour. It queries the hour before last, because we expect most of the component_event data for that hour to be ready by then.
In general this works fine, but we've noticed that the 01:15 run (which queries 23:00-00:00) is getting no data back from BigQuery.
E.g. -
<img width="826" height="409" alt="Screenshot 2025-07-24 at 10 51 18" src="https://github.com/user-attachments/assets/d6b87410-4087-4cad-9a2a-66309394fab8" />


Data Design have checked and told us:
"looks like the 23:00 - 23:59 run just takes ~2.5x as long as the usual hourly job."
They say it's always ready by 45mins past.

So this PR changes the schedule to run at 45 mins past the hour.