### PR TITLE
fix: update treatMissingData to NOT_BREACHING for alerting on no test…

### DIFF
--- a/cdk/lib/bandit.ts
+++ b/cdk/lib/bandit.ts
@@ -242,7 +242,7 @@ export class Bandit extends GuStack {
 			comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
 			evaluationPeriods: 1,
 			threshold: 1, // Alert if no tests have data
-			treatMissingData: TreatMissingData.BREACHING,
+			treatMissingData: TreatMissingData.NOT_BREACHING,
 		});
 	}
 }

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -68,5 +68,6 @@
       ".eslintrc.js",
       "jest.config.js"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
An attempt to prevent alerting when bandit data is zero.