### PR TITLE
fix: add dummy from to no variant query

### DIFF
--- a/bandit/src/query-lambda/build-query.ts
+++ b/bandit/src/query-lambda/build-query.ts
@@ -192,6 +192,7 @@ SELECT
     0 AS sum_av_gbp,
     0 AS sum_av_gbp_per_view,
     0 AS acquisitions
+FROM (SELECT 1) AS _
 WHERE NOT EXISTS (SELECT 1 FROM views)
 AND NOT EXISTS (SELECT 1 FROM acquisitions_agg)
 	`;


### PR DESCRIPTION
## What does this change?

Fix the no variant query by adding a dummy from to it.
