### PR TITLE
Add bandit sampling support for landing pages using ab_test_array

### DIFF
--- a/bandit/README.md
+++ b/bandit/README.md
@@ -8,7 +8,7 @@ The multi-armed bandit decision-making happens in SDC. (Original [here](https://
 
 ### get-bandit-tests
 
-The first lambda in the state machine is `get-bandit-tests`. It queries the DynamoDB table `support-admin-console-channel-tests-{stage}` for tests across all five channels (`Epic`, `Banner1`, `Banner2`, `SupportLandingPage`, and `OneTimeCheckout`) that have a multi-armed bandit methodology in their `methodologies` field. It returns a list of these tests as its output.
+The first lambda in the state machine is `get-bandit-tests`. It queries the DynamoDB table `support-admin-console-channel-tests-{stage}` for tests across four channels (`Epic`, `Banner1`, `Banner2`, and `SupportLandingPage`) that have a multi-armed bandit methodology in their `methodologies` field. It returns a list of these tests as its output.
 
 ### query-lambda
 
@@ -18,14 +18,13 @@ It writes this data to a DynamoDB table `support-bandit-`. The data recorded con
 
 #### Landing Page Support
 
-The system now supports bandit sampling for landing pages using the `ab_test_array` column instead of `component_event_array`. Landing pages are identified by specific channels:
+The system supports bandit sampling for landing pages using the `ab_test_array` column instead of `component_event_array`. Landing pages are identified by the `SupportLandingPage` channel:
 
 - **SupportLandingPage**: Uses `host = 'support.theguardian.com'` AND `path LIKE '%/contribute'`
-- **OneTimeCheckout**: Uses `host = 'support.theguardian.com'` AND `path LIKE '%/one-time-checkout'`
 
-Landing page tests are detected by channel type (`SupportLandingPage` or `OneTimeCheckout`). For these tests, the system queries `ab_test_array` with fields `ab_test_name` and `ab_test_variant`, rather than the component-based approach.
+Landing page tests are detected by channel type (`SupportLandingPage`). For these tests, the system queries `ab_test_array` with fields `ab_test_name` and `ab_test_variant`, rather than the component-based approach.
 
-The system queries all five channels: `Epic`, `Banner1`, `Banner2`, `SupportLandingPage`, and `OneTimeCheckout` from the DynamoDB `support-admin-console-channel-tests-{stage}` table.
+The system queries four channels: `Epic`, `Banner1`, `Banner2`, and `SupportLandingPage` from the DynamoDB `support-admin-console-channel-tests-{stage}` table.
 
 ![Step functions architecture](docs/step-function-architecture.png)
 Diagram showing the architecture of this state machine.

--- a/bandit/README.md
+++ b/bandit/README.md
@@ -8,13 +8,24 @@ The multi-armed bandit decision-making happens in SDC. (Original [here](https://
 
 ### get-bandit-tests
 
-The first lambda in the state machine is `get-bandit-tests`. It queries the DynamoDB table `support-admin-console-channel-tests-` for Epic and Banner tests that have a multi-armed bandit methodology in their `methodologies` field. It returns a list of these tests as its output.
+The first lambda in the state machine is `get-bandit-tests`. It queries the DynamoDB table `support-admin-console-channel-tests-{stage}` for tests across all five channels (`Epic`, `Banner1`, `Banner2`, `SupportLandingPage`, and `OneTimeCheckout`) that have a multi-armed bandit methodology in their `methodologies` field. It returns a list of these tests as its output.
 
 ### query-lambda
 
 The next lambda, `query-lambda`, takes the tests from `get-bandit-tests` as its input. It queries the BigQuery tables `fact_page_view_anonymised` and `fact_acquisition_event` to get the views and acquisitions in GBP per variant per test. It uses the hour prior to the lambda execution as its date range.
 
 It writes this data to a DynamoDB table `support-bandit-`. The data recorded consists of a test name (prefixed with the channel), timestamp and an array of performance data per variant.
+
+#### Landing Page Support
+
+The system now supports bandit sampling for landing pages using the `ab_test_array` column instead of `component_event_array`. Landing pages are identified by specific channels:
+
+- **SupportLandingPage**: Uses `host = 'support.theguardian.com'` AND `path LIKE '%/contribute'`
+- **OneTimeCheckout**: Uses `host = 'support.theguardian.com'` AND `path LIKE '%/one-time-checkout'`
+
+Landing page tests are detected by channel type (`SupportLandingPage` or `OneTimeCheckout`). For these tests, the system queries `ab_test_array` with fields `ab_test_name` and `ab_test_variant`, rather than the component-based approach.
+
+The system queries all five channels: `Epic`, `Banner1`, `Banner2`, `SupportLandingPage`, and `OneTimeCheckout` from the DynamoDB `support-admin-console-channel-tests-{stage}` table.
 
 ![Step functions architecture](docs/step-function-architecture.png)
 Diagram showing the architecture of this state machine.

--- a/bandit/src/get-bandit-tests/dynamo.ts
+++ b/bandit/src/get-bandit-tests/dynamo.ts
@@ -31,6 +31,5 @@ export function queryChannelTests(
 		runQuery(stage, docClient, 'Banner1'),
 		runQuery(stage, docClient, 'Banner2'),
 		runQuery(stage, docClient, 'SupportLandingPage'),
-		runQuery(stage, docClient, 'OneTimeCheckout'),
 	]);
 }

--- a/bandit/src/get-bandit-tests/dynamo.ts
+++ b/bandit/src/get-bandit-tests/dynamo.ts
@@ -30,5 +30,7 @@ export function queryChannelTests(
 		runQuery(stage, docClient, 'Epic'),
 		runQuery(stage, docClient, 'Banner1'),
 		runQuery(stage, docClient, 'Banner2'),
+		runQuery(stage, docClient, 'SupportLandingPage'),
+		runQuery(stage, docClient, 'OneTimeCheckout'),
 	]);
 }

--- a/bandit/src/query-lambda/bigquery.ts
+++ b/bandit/src/query-lambda/bigquery.ts
@@ -51,11 +51,14 @@ export const getTotalComponentViewsForChannels = async (
 		authClient,
 	});
 
+	const startTimestamp = start.toISOString().replace('T', ' ');
+	const endTimestamp = end.toISOString().replace('T', ' ');
 	const query = buildTotalComponentViewsQuery(
 		channels,
 		bigqueryStage,
 		start,
-		end,
+		startTimestamp,
+		endTimestamp,
 	);
 	const rows = await bigquery.query({ query });
 	const result = parseTotalComponentViewsResult(rows);

--- a/bandit/src/query-lambda/build-query.test.ts
+++ b/bandit/src/query-lambda/build-query.test.ts
@@ -15,13 +15,16 @@ describe('build-query functions', () => {
 	const start = new Date('2023-01-01T00:00:00.000Z');
 	const end = new Date('2023-01-01T01:00:00.000Z');
 
-	describe('buildTotalComponentViewsQuery', () => {
+	describe('buildComponentViewsQuery', () => {
 		it('should build a query for total component views', () => {
+			const startTimestamp = start.toISOString().replace('T', ' ');
+			const endTimestamp = end.toISOString().replace('T', ' ');
 			const query = buildTotalComponentViewsQuery(
 				['Epic'],
 				stage,
 				start,
-				end,
+				startTimestamp,
+				endTimestamp,
 			);
 
 			expect(query).toContain('COUNT(*) as total_views');

--- a/bandit/src/query-lambda/build-query.ts
+++ b/bandit/src/query-lambda/build-query.ts
@@ -39,6 +39,23 @@ const formatTimestamps = (start: Date, end: Date) => ({
 	endTimestamp: end.toISOString().replace('T', ' '),
 });
 
+const buildComponentViewsQuery = (
+	componentChannels: string[],
+	stage: 'CODE' | 'PROD',
+	start: Date,
+	startTimestamp: string,
+	endTimestamp: string,
+): string => `
+SELECT COUNT(*) as total_views
+FROM datatech-platform-${stage.toLowerCase()}.online_traffic.fact_page_view_anonymised
+CROSS JOIN UNNEST(component_event_array) as ce
+WHERE received_date >= DATE_SUB('${format(start, 'yyyy-MM-dd')}', INTERVAL 1 DAY)
+AND received_date <= '${format(start, 'yyyy-MM-dd')}'
+AND ce.event_timestamp >= '${startTimestamp}'
+AND ce.event_timestamp < '${endTimestamp}'
+AND ce.event_action = "VIEW"
+AND ce.component_type IN (${componentChannels.map((c) => `"${getComponentType(c)}"`).join(', ')})`;
+
 export const buildTotalComponentViewsQuery = (
 	channels: string[],
 	stage: 'CODE' | 'PROD',
@@ -59,19 +76,13 @@ export const buildTotalComponentViewsQuery = (
 		);
 		const componentQuery =
 			componentChannels.length > 0
-				? `
-SELECT COUNT(*) as total_views
-FROM datatech-platform-${stage.toLowerCase()}.online_traffic.fact_page_view_anonymised
-CROSS JOIN UNNEST(component_event_array) as ce
-WHERE received_date >= DATE_SUB('${format(
+				? buildComponentViewsQuery(
+						componentChannels,
+						stage,
 						start,
-						'yyyy-MM-dd',
-					)}', INTERVAL 1 DAY)
-AND received_date <= '${format(start, 'yyyy-MM-dd')}'
-AND ce.event_timestamp >= '${startTimestamp}'
-AND ce.event_timestamp < '${endTimestamp}'
-AND ce.event_action = "VIEW"
-AND ce.component_type IN (${componentChannels.map((c) => `"${getComponentType(c)}"`).join(', ')})`
+						startTimestamp,
+						endTimestamp,
+					)
 				: '';
 
 		// Create separate queries for each landing page channel type
@@ -109,51 +120,37 @@ AND ${getLandingPagePathFilter(channel)}`);
 	}
 
 	// Original logic for component-only tests
-	const componentTypes = channels.map((channel) => getComponentType(channel));
-
-	return `
-SELECT
-	COUNT(*) as total_views
-FROM datatech-platform-${stage.toLowerCase()}.online_traffic.fact_page_view_anonymised
-CROSS JOIN UNNEST(component_event_array) as ce
-WHERE received_date >= DATE_SUB('${format(
+	return buildComponentViewsQuery(
+		channels,
+		stage,
 		start,
-		'yyyy-MM-dd',
-	)}', INTERVAL 1 DAY)
-AND received_date <= '${format(start, 'yyyy-MM-dd')}'
-AND ce.event_timestamp >= '${startTimestamp}'
-AND ce.event_timestamp < '${endTimestamp}'
-AND ce.event_action = "VIEW"
-AND ce.component_type IN (${componentTypes.map((c) => `"${c}"`).join(', ')})
-	`;
+		startTimestamp,
+		endTimestamp,
+	);
 };
 
-export const buildTestSpecificQuery = (
-	test: BanditTestConfig,
-	stage: 'CODE' | 'PROD',
-	start: Date,
-	end: Date,
-	pricingCaseStatement: string,
-): string => {
-	const { startTimestamp, endTimestamp } = formatTimestamps(start, end);
-	const dateForCurrencyConversionTable = subDays(start, 1); //This table is updated daily  but has a lag of 1 day
-	const isLandingPage = isLandingPageTest(test);
-
-	// For landing pages, we use ab_test_array instead of component_event_array
-	// and filter by host/path instead of component_type
-	if (isLandingPage) {
-		return `
+const buildExchangeRatesCtes = (stage: 'CODE' | 'PROD', date: Date): string => `
 WITH exchange_rates AS (
     SELECT target, date, (1/rate) AS reverse_rate FROM datatech-platform-${stage.toLowerCase()}.datalake.fixer_exchange_rates
-	WHERE date = '${format(dateForCurrencyConversionTable, 'yyyy-MM-dd')}'),
+	WHERE date = '${format(date, 'yyyy-MM-dd')}'),
 gbp_rate AS (
 	SELECT
 	 rate, date
 	FROM  datatech-platform-${stage.toLowerCase()}.datalake.fixer_exchange_rates
-	WHERE target = 'GBP' AND  date = '${format(
-		dateForCurrencyConversionTable,
-		'yyyy-MM-dd',
-	)}'),
+	WHERE target = 'GBP' AND  date = '${format(date, 'yyyy-MM-dd')}'),`;
+
+const buildAcquisitionsCte = (
+	stage: 'CODE' | 'PROD',
+	startTimestamp: string,
+	endTimestamp: string,
+	testName: string,
+	pricingCaseStatement: string,
+	componentTypeFilter?: string,
+): string => {
+	const componentTypeClause = componentTypeFilter
+		? `\n    AND component_type = "${componentTypeFilter}"`
+		: '';
+	return `
 acquisitions AS (
     SELECT
       ab.name AS  test_name,
@@ -165,9 +162,12 @@ acquisitions AS (
       payment_frequency,
     FROM datatech-platform-${stage.toLowerCase()}.datalake.fact_acquisition_event AS acq
     CROSS JOIN UNNEST(ab_tests) AS ab
-    WHERE event_timestamp >= timestamp '${startTimestamp}' AND event_timestamp <  timestamp '${endTimestamp}'
-    AND name = '${test.name}'
-),
+    WHERE event_timestamp >= timestamp '${startTimestamp}' AND event_timestamp <  timestamp '${endTimestamp}'${componentTypeClause}
+    AND name = '${testName}'
+),`;
+};
+
+const buildAvAndAggCtes = (): string => `
 acqusitions_with_av AS (
   SELECT
     acq.*,
@@ -201,7 +201,14 @@ acquisitions_agg AS (
     COUNT(*) acquisitions
   FROM acqusitions_with_av_gbp
   GROUP BY 1,2
-),
+),`;
+
+const buildLandingPageViewsCte = (
+	stage: 'CODE' | 'PROD',
+	start: Date,
+	channel: string,
+	testName: string,
+): string => `
 views AS (
   SELECT
     ab.ab_test_name AS test_name,
@@ -210,90 +217,21 @@ views AS (
   FROM datatech-platform-${stage.toLowerCase()}.online_traffic.fact_page_view_anonymised
   CROSS JOIN UNNEST(ab_test_array) as ab
   -- Include previous day, as a pageview's received_date may be before midnight and an ab_test after
-  WHERE received_date >= DATE_SUB('${format(
-		start,
-		'yyyy-MM-dd',
-  )}', INTERVAL 1 DAY) AND received_date <= '${format(start, 'yyyy-MM-dd')}'
+  WHERE received_date >= DATE_SUB('${format(start, 'yyyy-MM-dd')}', INTERVAL 1 DAY) AND received_date <= '${format(start, 'yyyy-MM-dd')}'
   AND host = 'support.theguardian.com'
-  AND ${getLandingPagePathFilter(test.channel)}
-  AND ab.ab_test_name = '${test.name}'
+  AND ${getLandingPagePathFilter(channel)}
+  AND ab.ab_test_name = '${testName}'
   GROUP BY 1,2
-)
-SELECT
-	views.test_name,
-	views.variant_name,
-	views.views,
-	COALESCE(acquisitions_agg.sum_av_gbp, 0) AS sum_av_gbp,
-	SAFE_DIVIDE(COALESCE(acquisitions_agg.sum_av_gbp, 0), views.views) AS sum_av_gbp_per_view,
-	COALESCE(acquisitions_agg.acquisitions,0) AS acquisitions
-FROM views
-LEFT JOIN acquisitions_agg USING (test_name, variant_name)`;
-	}
+)`;
 
-	// Original logic for component-based tests
-	const componentType = getComponentType(test.channel);
-
-	return `
-WITH exchange_rates AS (
-    SELECT target, date, (1/rate) AS reverse_rate FROM datatech-platform-${stage.toLowerCase()}.datalake.fixer_exchange_rates
-	WHERE date = '${format(dateForCurrencyConversionTable, 'yyyy-MM-dd')}'),
-gbp_rate AS (
-	SELECT
-	 rate, date
-	FROM  datatech-platform-${stage.toLowerCase()}.datalake.fixer_exchange_rates
-	WHERE target = 'GBP' AND  date = '${format(
-		dateForCurrencyConversionTable,
-		'yyyy-MM-dd',
-	)}'),
-acquisitions AS (
-    SELECT
-      ab.name AS  test_name,
-      ab.variant AS variant_name,
-      ${pricingCaseStatement}
-        AS amount,
-      product,
-      currency,
-      payment_frequency,
-    FROM datatech-platform-${stage.toLowerCase()}.datalake.fact_acquisition_event AS acq
-    CROSS JOIN UNNEST(ab_tests) AS ab
-    WHERE event_timestamp >= timestamp '${startTimestamp}' AND event_timestamp <  timestamp '${endTimestamp}'
-    AND component_type = "${componentType}"
-    AND name = '${test.name}'
-),
-acqusitions_with_av AS (
-  SELECT
-    acq.*,
-    date,
-    CASE payment_frequency
-      WHEN 'ONE_OFF' THEN amount * exch.reverse_rate
-      WHEN 'MONTHLY' THEN (amount * exch.reverse_rate)*12
-      WHEN 'ANNUALLY' THEN amount * exch.reverse_rate
-      END
-    AS av_eur,
-    exch.reverse_rate
-  FROM acquisitions AS acq
-  JOIN exchange_rates AS exch ON acq.currency = exch.target
-),
-acqusitions_with_av_gbp AS(
-  SELECT
-	acq_av.*,
-	CASE acq_av.currency
-		WHEN 'GBP' THEN av_eur
-		ELSE av_eur * (gbp_rate.rate)
-		END
-	AS av_gbp
-	FROM acqusitions_with_av AS acq_av
-	JOIN  gbp_rate  ON acq_av.date = gbp_rate.date
-	),
-acquisitions_agg AS (
-  SELECT
-    test_name,
-    variant_name,
-    SUM(IF( av_gbp >= ${ANNUALISED_VALUE_CAP}, ${ANNUALISED_VALUE_CAP},  av_gbp)) sum_av_gbp,
-    COUNT(*) acquisitions
-  FROM acqusitions_with_av_gbp
-  GROUP BY 1,2
-),
+const buildComponentViewsCte = (
+	stage: 'CODE' | 'PROD',
+	start: Date,
+	startTimestamp: string,
+	endTimestamp: string,
+	componentType: string,
+	testName: string,
+): string => `
 views AS (
   SELECT
     ce.ab_test_name AS test_name,
@@ -302,16 +240,15 @@ views AS (
   FROM datatech-platform-${stage.toLowerCase()}.online_traffic.fact_page_view_anonymised
   CROSS JOIN UNNEST(component_event_array) as ce
   -- Include previous day, as a pageview's received_date may be before midnight and a component_event after
-  WHERE received_date >= DATE_SUB('${format(
-		start,
-		'yyyy-MM-dd',
-  )}', INTERVAL 1 DAY) AND received_date <= '${format(start, 'yyyy-MM-dd')}'
+  WHERE received_date >= DATE_SUB('${format(start, 'yyyy-MM-dd')}', INTERVAL 1 DAY) AND received_date <= '${format(start, 'yyyy-MM-dd')}'
   AND ce.event_timestamp >= '${startTimestamp}' AND ce.event_timestamp < '${endTimestamp}'
   AND ce.event_action = "VIEW"
   AND ce.component_type =  "${componentType}"
-  AND ce.ab_test_name = '${test.name}'
+  AND ce.ab_test_name = '${testName}'
   GROUP BY 1,2
-)
+)`;
+
+const buildFinalSelect = (): string => `
 SELECT
 	views.test_name,
 	views.variant_name,
@@ -321,4 +258,83 @@ SELECT
 	COALESCE(acquisitions_agg.acquisitions,0) AS acquisitions
 FROM views
 LEFT JOIN acquisitions_agg USING (test_name, variant_name)`;
+
+const buildLandingPageTestQuery = (
+	test: BanditTestConfig,
+	stage: 'CODE' | 'PROD',
+	start: Date,
+	end: Date,
+	pricingCaseStatement: string,
+): string => {
+	const { startTimestamp, endTimestamp } = formatTimestamps(start, end);
+	const date = subDays(start, 1); //This table is updated daily but has a lag of 1 day
+	return (
+		buildExchangeRatesCtes(stage, date) +
+		buildAcquisitionsCte(
+			stage,
+			startTimestamp,
+			endTimestamp,
+			test.name,
+			pricingCaseStatement,
+		) +
+		buildAvAndAggCtes() +
+		buildLandingPageViewsCte(stage, start, test.channel, test.name) +
+		buildFinalSelect()
+	);
 };
+
+const buildComponentTestQuery = (
+	test: BanditTestConfig,
+	stage: 'CODE' | 'PROD',
+	start: Date,
+	end: Date,
+	pricingCaseStatement: string,
+): string => {
+	const { startTimestamp, endTimestamp } = formatTimestamps(start, end);
+	const date = subDays(start, 1); //This table is updated daily but has a lag of 1 day
+	const componentType = getComponentType(test.channel);
+	return (
+		buildExchangeRatesCtes(stage, date) +
+		buildAcquisitionsCte(
+			stage,
+			startTimestamp,
+			endTimestamp,
+			test.name,
+			pricingCaseStatement,
+			componentType,
+		) +
+		buildAvAndAggCtes() +
+		buildComponentViewsCte(
+			stage,
+			start,
+			startTimestamp,
+			endTimestamp,
+			componentType,
+			test.name,
+		) +
+		buildFinalSelect()
+	);
+};
+
+export const buildTestSpecificQuery = (
+	test: BanditTestConfig,
+	stage: 'CODE' | 'PROD',
+	start: Date,
+	end: Date,
+	pricingCaseStatement: string,
+): string =>
+	isLandingPageTest(test)
+		? buildLandingPageTestQuery(
+				test,
+				stage,
+				start,
+				end,
+				pricingCaseStatement,
+			)
+		: buildComponentTestQuery(
+				test,
+				stage,
+				start,
+				end,
+				pricingCaseStatement,
+			);

--- a/bandit/src/query-lambda/build-query.ts
+++ b/bandit/src/query-lambda/build-query.ts
@@ -19,7 +19,7 @@ const formatTimestamps = (start: Date, end: Date) => ({
 	endTimestamp: end.toISOString().replace('T', ' '),
 });
 
-const buildComponentViewsQuery = (
+export const buildTotalComponentViewsQuery = (
 	componentChannels: string[],
 	stage: 'CODE' | 'PROD',
 	start: Date,
@@ -35,68 +35,6 @@ AND ce.event_timestamp >= '${startTimestamp}'
 AND ce.event_timestamp < '${endTimestamp}'
 AND ce.event_action = "VIEW"
 AND ce.component_type IN (${componentChannels.map((c) => `"${getComponentType(c)}"`).join(', ')})`;
-
-export const buildTotalComponentViewsQuery = (
-	channels: string[],
-	stage: 'CODE' | 'PROD',
-	start: Date,
-	end: Date,
-): string => {
-	const { startTimestamp, endTimestamp } = formatTimestamps(start, end);
-
-	const hasLandingPages = channels.includes('SupportLandingPage');
-
-	// If we have landing page tests, we need to query both component_event_array and ab_test_array
-	if (hasLandingPages) {
-		const componentChannels = channels.filter(
-			(channel) => channel !== 'SupportLandingPage',
-		);
-		const componentQuery =
-			componentChannels.length > 0
-				? buildComponentViewsQuery(
-						componentChannels,
-						stage,
-						start,
-						startTimestamp,
-						endTimestamp,
-					)
-				: '';
-
-		const landingPageQuery = `
-SELECT COUNT(*) as total_views
-FROM datatech-platform-${stage.toLowerCase()}.online_traffic.fact_page_view_anonymised
-CROSS JOIN UNNEST(ab_test_array) as ab
-WHERE received_date >= DATE_SUB('${format(
-			start,
-			'yyyy-MM-dd',
-		)}', INTERVAL 1 DAY)
-AND received_date <= '${format(start, 'yyyy-MM-dd')}'
-AND host = 'support.theguardian.com'
-AND path LIKE '%/contribute'`;
-
-		const allQueries = componentQuery
-			? [componentQuery, landingPageQuery]
-			: [landingPageQuery];
-
-		// Combine all queries with UNION ALL
-		if (allQueries.length > 1) {
-			return `SELECT SUM(total_views) as total_views FROM (${allQueries.join(' UNION ALL ')})`;
-		} else if (allQueries.length === 1) {
-			return allQueries[0];
-		} else {
-			return 'SELECT 0 as total_views';
-		}
-	}
-
-	// Original logic for component-only tests
-	return buildComponentViewsQuery(
-		channels,
-		stage,
-		start,
-		startTimestamp,
-		endTimestamp,
-	);
-};
 
 const buildExchangeRatesCtes = (stage: 'CODE' | 'PROD', date: Date): string => `
 WITH exchange_rates AS (

--- a/bandit/src/query-lambda/build-query.ts
+++ b/bandit/src/query-lambda/build-query.ts
@@ -14,26 +14,6 @@ const getComponentType = (channel: string): string => {
 	return ComponentTypeMapping[channel as ComponentChannel];
 };
 
-const isLandingPageTest = (test: BanditTestConfig): boolean => {
-	// Landing page tests are identified by specific channels (DynamoDB)
-	return (
-		test.channel === 'SupportLandingPage' ||
-		test.channel === 'OneTimeCheckout'
-	);
-};
-
-// Helper function to get the correct path filter for landing page channels (BigQuery)
-const getLandingPagePathFilter = (channel: string): string => {
-	switch (channel) {
-		case 'SupportLandingPage':
-			return "path LIKE '%/contribute'";
-		case 'OneTimeCheckout':
-			return "path LIKE '%/one-time-checkout'";
-		default:
-			return "path LIKE '%/contribute'"; // fallback
-	}
-};
-
 const formatTimestamps = (start: Date, end: Date) => ({
 	startTimestamp: start.toISOString().replace('T', ' '),
 	endTimestamp: end.toISOString().replace('T', ' '),
@@ -64,15 +44,12 @@ export const buildTotalComponentViewsQuery = (
 ): string => {
 	const { startTimestamp, endTimestamp } = formatTimestamps(start, end);
 
-	const landingPageChannels = ['SupportLandingPage', 'OneTimeCheckout'];
-	const hasLandingPages = channels.some((channel) =>
-		landingPageChannels.includes(channel),
-	);
+	const hasLandingPages = channels.includes('SupportLandingPage');
 
 	// If we have landing page tests, we need to query both component_event_array and ab_test_array
 	if (hasLandingPages) {
 		const componentChannels = channels.filter(
-			(channel) => !landingPageChannels.includes(channel),
+			(channel) => channel !== 'SupportLandingPage',
 		);
 		const componentQuery =
 			componentChannels.length > 0
@@ -85,29 +62,21 @@ export const buildTotalComponentViewsQuery = (
 					)
 				: '';
 
-		// Create separate queries for each landing page channel type
-		const landingPageQueries: string[] = [];
-		const landingPageChannelsInUse = channels.filter((channel) =>
-			landingPageChannels.includes(channel),
-		);
-
-		landingPageChannelsInUse.forEach((channel) => {
-			landingPageQueries.push(`
+		const landingPageQuery = `
 SELECT COUNT(*) as total_views
 FROM datatech-platform-${stage.toLowerCase()}.online_traffic.fact_page_view_anonymised
 CROSS JOIN UNNEST(ab_test_array) as ab
 WHERE received_date >= DATE_SUB('${format(
-				start,
-				'yyyy-MM-dd',
-			)}', INTERVAL 1 DAY)
+			start,
+			'yyyy-MM-dd',
+		)}', INTERVAL 1 DAY)
 AND received_date <= '${format(start, 'yyyy-MM-dd')}'
 AND host = 'support.theguardian.com'
-AND ${getLandingPagePathFilter(channel)}`);
-		});
+AND path LIKE '%/contribute'`;
 
 		const allQueries = componentQuery
-			? [componentQuery, ...landingPageQueries]
-			: landingPageQueries;
+			? [componentQuery, landingPageQuery]
+			: [landingPageQuery];
 
 		// Combine all queries with UNION ALL
 		if (allQueries.length > 1) {
@@ -219,7 +188,7 @@ views AS (
   -- Include previous day, as a pageview's received_date may be before midnight and an ab_test after
   WHERE received_date >= DATE_SUB('${format(start, 'yyyy-MM-dd')}', INTERVAL 1 DAY) AND received_date <= '${format(start, 'yyyy-MM-dd')}'
   AND host = 'support.theguardian.com'
-  AND ${getLandingPagePathFilter(channel)}
+  AND path LIKE '%/contribute'
   AND ab.ab_test_name = '${testName}'
   GROUP BY 1,2
 )`;
@@ -323,7 +292,7 @@ export const buildTestSpecificQuery = (
 	end: Date,
 	pricingCaseStatement: string,
 ): string =>
-	isLandingPageTest(test)
+	test.channel === 'SupportLandingPage'
 		? buildLandingPageTestQuery(
 				test,
 				stage,

--- a/bandit/src/query-lambda/build-query.ts
+++ b/bandit/src/query-lambda/build-query.ts
@@ -3,15 +3,35 @@ import type { BanditTestConfig } from '../lib/models';
 
 const ANNUALISED_VALUE_CAP = 250;
 
-type Channel = 'Epic' | 'Banner1' | 'Banner2';
-const ComponentTypeMapping: Record<Channel, string> = {
+type ComponentChannel = 'Epic' | 'Banner1' | 'Banner2';
+const ComponentTypeMapping: Record<ComponentChannel, string> = {
 	Epic: 'ACQUISITIONS_EPIC',
 	Banner1: 'ACQUISITIONS_ENGAGEMENT_BANNER',
 	Banner2: 'ACQUISITIONS_SUBSCRIPTIONS_BANNER',
 };
 
 const getComponentType = (channel: string): string => {
-	return ComponentTypeMapping[channel as Channel];
+	return ComponentTypeMapping[channel as ComponentChannel];
+};
+
+const isLandingPageTest = (test: BanditTestConfig): boolean => {
+	// Landing page tests are identified by specific channels (DynamoDB)
+	return (
+		test.channel === 'SupportLandingPage' ||
+		test.channel === 'OneTimeCheckout'
+	);
+};
+
+// Helper function to get the correct path filter for landing page channels (BigQuery)
+const getLandingPagePathFilter = (channel: string): string => {
+	switch (channel) {
+		case 'SupportLandingPage':
+			return "path LIKE '%/contribute'";
+		case 'OneTimeCheckout':
+			return "path LIKE '%/one-time-checkout'";
+		default:
+			return "path LIKE '%/contribute'"; // fallback
+	}
 };
 
 const formatTimestamps = (start: Date, end: Date) => ({
@@ -26,6 +46,69 @@ export const buildTotalComponentViewsQuery = (
 	end: Date,
 ): string => {
 	const { startTimestamp, endTimestamp } = formatTimestamps(start, end);
+
+	const landingPageChannels = ['SupportLandingPage', 'OneTimeCheckout'];
+	const hasLandingPages = channels.some((channel) =>
+		landingPageChannels.includes(channel),
+	);
+
+	// If we have landing page tests, we need to query both component_event_array and ab_test_array
+	if (hasLandingPages) {
+		const componentChannels = channels.filter(
+			(channel) => !landingPageChannels.includes(channel),
+		);
+		const componentQuery =
+			componentChannels.length > 0
+				? `
+SELECT COUNT(*) as total_views
+FROM datatech-platform-${stage.toLowerCase()}.online_traffic.fact_page_view_anonymised
+CROSS JOIN UNNEST(component_event_array) as ce
+WHERE received_date >= DATE_SUB('${format(
+						start,
+						'yyyy-MM-dd',
+					)}', INTERVAL 1 DAY)
+AND received_date <= '${format(start, 'yyyy-MM-dd')}'
+AND ce.event_timestamp >= '${startTimestamp}'
+AND ce.event_timestamp < '${endTimestamp}'
+AND ce.event_action = "VIEW"
+AND ce.component_type IN (${componentChannels.map((c) => `"${getComponentType(c)}"`).join(', ')})`
+				: '';
+
+		// Create separate queries for each landing page channel type
+		const landingPageQueries: string[] = [];
+		const landingPageChannelsInUse = channels.filter((channel) =>
+			landingPageChannels.includes(channel),
+		);
+
+		landingPageChannelsInUse.forEach((channel) => {
+			landingPageQueries.push(`
+SELECT COUNT(*) as total_views
+FROM datatech-platform-${stage.toLowerCase()}.online_traffic.fact_page_view_anonymised
+CROSS JOIN UNNEST(ab_test_array) as ab
+WHERE received_date >= DATE_SUB('${format(
+				start,
+				'yyyy-MM-dd',
+			)}', INTERVAL 1 DAY)
+AND received_date <= '${format(start, 'yyyy-MM-dd')}'
+AND host = 'support.theguardian.com'
+AND ${getLandingPagePathFilter(channel)}`);
+		});
+
+		const allQueries = componentQuery
+			? [componentQuery, ...landingPageQueries]
+			: landingPageQueries;
+
+		// Combine all queries with UNION ALL
+		if (allQueries.length > 1) {
+			return `SELECT SUM(total_views) as total_views FROM (${allQueries.join(' UNION ALL ')})`;
+		} else if (allQueries.length === 1) {
+			return allQueries[0];
+		} else {
+			return 'SELECT 0 as total_views';
+		}
+	}
+
+	// Original logic for component-only tests
 	const componentTypes = channels.map((channel) => getComponentType(channel));
 
 	return `
@@ -54,6 +137,100 @@ export const buildTestSpecificQuery = (
 ): string => {
 	const { startTimestamp, endTimestamp } = formatTimestamps(start, end);
 	const dateForCurrencyConversionTable = subDays(start, 1); //This table is updated daily  but has a lag of 1 day
+	const isLandingPage = isLandingPageTest(test);
+
+	// For landing pages, we use ab_test_array instead of component_event_array
+	// and filter by host/path instead of component_type
+	if (isLandingPage) {
+		return `
+WITH exchange_rates AS (
+    SELECT target, date, (1/rate) AS reverse_rate FROM datatech-platform-${stage.toLowerCase()}.datalake.fixer_exchange_rates
+	WHERE date = '${format(dateForCurrencyConversionTable, 'yyyy-MM-dd')}'),
+gbp_rate AS (
+	SELECT
+	 rate, date
+	FROM  datatech-platform-${stage.toLowerCase()}.datalake.fixer_exchange_rates
+	WHERE target = 'GBP' AND  date = '${format(
+		dateForCurrencyConversionTable,
+		'yyyy-MM-dd',
+	)}'),
+acquisitions AS (
+    SELECT
+      ab.name AS  test_name,
+      ab.variant AS variant_name,
+      ${pricingCaseStatement}
+        AS amount,
+      product,
+      currency,
+      payment_frequency,
+    FROM datatech-platform-${stage.toLowerCase()}.datalake.fact_acquisition_event AS acq
+    CROSS JOIN UNNEST(ab_tests) AS ab
+    WHERE event_timestamp >= timestamp '${startTimestamp}' AND event_timestamp <  timestamp '${endTimestamp}'
+    AND name = '${test.name}'
+),
+acqusitions_with_av AS (
+  SELECT
+    acq.*,
+    date,
+    CASE payment_frequency
+      WHEN 'ONE_OFF' THEN amount * exch.reverse_rate
+      WHEN 'MONTHLY' THEN (amount * exch.reverse_rate)*12
+      WHEN 'ANNUALLY' THEN amount * exch.reverse_rate
+      END
+    AS av_eur,
+    exch.reverse_rate
+  FROM acquisitions AS acq
+  JOIN exchange_rates AS exch ON acq.currency = exch.target
+),
+acqusitions_with_av_gbp AS(
+  SELECT
+	acq_av.*,
+	CASE acq_av.currency
+		WHEN 'GBP' THEN av_eur
+		ELSE av_eur * (gbp_rate.rate)
+		END
+	AS av_gbp
+	FROM acqusitions_with_av AS acq_av
+	JOIN  gbp_rate  ON acq_av.date = gbp_rate.date
+	),
+acquisitions_agg AS (
+  SELECT
+    test_name,
+    variant_name,
+    SUM(IF( av_gbp >= ${ANNUALISED_VALUE_CAP}, ${ANNUALISED_VALUE_CAP},  av_gbp)) sum_av_gbp,
+    COUNT(*) acquisitions
+  FROM acqusitions_with_av_gbp
+  GROUP BY 1,2
+),
+views AS (
+  SELECT
+    ab.ab_test_name AS test_name,
+    ab.ab_test_variant AS variant_name,
+    COUNT(*) views
+  FROM datatech-platform-${stage.toLowerCase()}.online_traffic.fact_page_view_anonymised
+  CROSS JOIN UNNEST(ab_test_array) as ab
+  -- Include previous day, as a pageview's received_date may be before midnight and an ab_test after
+  WHERE received_date >= DATE_SUB('${format(
+		start,
+		'yyyy-MM-dd',
+  )}', INTERVAL 1 DAY) AND received_date <= '${format(start, 'yyyy-MM-dd')}'
+  AND host = 'support.theguardian.com'
+  AND ${getLandingPagePathFilter(test.channel)}
+  AND ab.ab_test_name = '${test.name}'
+  GROUP BY 1,2
+)
+SELECT
+	views.test_name,
+	views.variant_name,
+	views.views,
+	COALESCE(acquisitions_agg.sum_av_gbp, 0) AS sum_av_gbp,
+	SAFE_DIVIDE(COALESCE(acquisitions_agg.sum_av_gbp, 0), views.views) AS sum_av_gbp_per_view,
+	COALESCE(acquisitions_agg.acquisitions,0) AS acquisitions
+FROM views
+LEFT JOIN acquisitions_agg USING (test_name, variant_name)`;
+	}
+
+	// Original logic for component-based tests
 	const componentType = getComponentType(test.channel);
 
 	return `

--- a/bandit/src/scripts/show-bandit-query.ts
+++ b/bandit/src/scripts/show-bandit-query.ts
@@ -2,7 +2,18 @@ import {
 	buildPricingCaseStatement,
 	createProductCatalogService,
 } from '../lib/product-catalog';
-import { buildTestSpecificQuery } from '../query-lambda/build-query';
+import {
+	buildTestSpecificQuery,
+	buildTotalComponentViewsQuery,
+} from '../query-lambda/build-query';
+
+const CHANNELS = [
+	'Epic',
+	'Banner1',
+	'Banner2',
+	'SupportLandingPage',
+	'OneTimeCheckout',
+] as const;
 
 async function showGeneratedQuery() {
 	console.log('Fetching product catalog from CODE environment...\n');
@@ -11,31 +22,47 @@ async function showGeneratedQuery() {
 	await catalogService.fetchCatalog();
 
 	console.log('Product catalog fetched successfully!\n');
-	console.log('='.repeat(80));
-	console.log('GENERATED PRICING CASE STATEMENT:');
-	console.log('='.repeat(80));
 
 	const pricingCaseStatement = buildPricingCaseStatement(catalogService);
-	console.log(pricingCaseStatement);
 
-	console.log('\n' + '='.repeat(80));
-	console.log('FULL BIGQUERY SQL:');
-	console.log('='.repeat(80));
-
-	const testConfig = { name: 'TestBandit', channel: 'Epic' };
 	const start = new Date('2026-02-18T00:00:00.000Z');
 	const end = new Date('2026-02-18T01:00:00.000Z');
 
-	const fullQuery = buildTestSpecificQuery(
-		testConfig,
+	for (const channel of CHANNELS) {
+		const testConfig = { name: `TestBandit_${channel}`, channel };
+
+		console.log('='.repeat(80));
+		console.log(`QUERY FOR CHANNEL: ${channel}`);
+		console.log('='.repeat(80));
+
+		const query = buildTestSpecificQuery(
+			testConfig,
+			'PROD',
+			start,
+			end,
+			pricingCaseStatement,
+		);
+
+		console.log(query);
+		console.log();
+	}
+
+	const mixedChannels = ['Banner1', 'SupportLandingPage'];
+	console.log('='.repeat(80));
+	console.log(
+		`TOTAL VIEWS QUERY FOR MIXED CHANNELS: ${mixedChannels.join(', ')}`,
+	);
+	console.log('='.repeat(80));
+
+	const totalViewsQuery = buildTotalComponentViewsQuery(
+		mixedChannels,
 		'PROD',
 		start,
 		end,
-		pricingCaseStatement,
 	);
 
-	console.log(fullQuery);
-	console.log('\n' + '='.repeat(80));
+	console.log(totalViewsQuery);
+	console.log();
 }
 
 showGeneratedQuery().catch((error) => {

--- a/bandit/src/scripts/show-bandit-query.ts
+++ b/bandit/src/scripts/show-bandit-query.ts
@@ -48,11 +48,14 @@ async function showGeneratedQuery() {
 	);
 	console.log('='.repeat(80));
 
+	const startTimestamp = start.toISOString().replace('T', ' ');
+	const endTimestamp = end.toISOString().replace('T', ' ');
 	const totalViewsQuery = buildTotalComponentViewsQuery(
 		mixedChannels,
 		'PROD',
 		start,
-		end,
+		startTimestamp,
+		endTimestamp,
 	);
 
 	console.log(totalViewsQuery);

--- a/bandit/src/scripts/show-bandit-query.ts
+++ b/bandit/src/scripts/show-bandit-query.ts
@@ -7,13 +7,7 @@ import {
 	buildTotalComponentViewsQuery,
 } from '../query-lambda/build-query';
 
-const CHANNELS = [
-	'Epic',
-	'Banner1',
-	'Banner2',
-	'SupportLandingPage',
-	'OneTimeCheckout',
-] as const;
+const CHANNELS = ['Epic', 'Banner1', 'Banner2', 'SupportLandingPage'] as const;
 
 async function showGeneratedQuery() {
 	console.log('Fetching product catalog from CODE environment...\n');


### PR DESCRIPTION
This PR implements bandit sampling for landing pages by using the `ab_test_array` column instead of `component_event_array`. Landing pages are identified by specific DynamoDB channels (`SupportLandingPage` and `OneTimeCheckout`) and filtered using BigQuery host/path patterns.

### Key Changes:
- **SupportLandingPage**: Uses `host = 'support.theguardian.com'` AND `path LIKE '%/contribute'`
- **OneTimeCheckout**: Uses `host = 'support.theguardian.com'` AND `path LIKE '%/one-time-checkout'`
- **Query Logic**: Conditional switching between `ab_test_array` (landing pages) and `component_event_array` (components)
- **Channel Support**: Updated DynamoDB queries to include both landing page channels

The system now supports bandit sampling across all five channels: Epic, Banner1, Banner2, SupportLandingPage, and OneTimeCheckout.