### PR TITLE
Fix DynamoDB BatchWriteItem 25-item limit exceeded

### DIFF
--- a/bandit/src/query-lambda/dynamo.test.ts
+++ b/bandit/src/query-lambda/dynamo.test.ts
@@ -1,0 +1,125 @@
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+import { buildWriteRequest, writeBatch } from './dynamo';
+import type { DocumentWriteRequest } from './dynamo';
+import type { VariantQueryRow } from './parse-result';
+
+jest.mock('@aws-sdk/lib-dynamodb', () => ({
+	BatchWriteCommand: jest.fn((input: unknown) => ({ input })),
+}));
+
+describe('writeBatch', () => {
+	let sendMock: jest.Mock;
+	let mockDocClient: { send: jest.Mock };
+
+	beforeEach(() => {
+		sendMock = jest.fn().mockResolvedValue({ $metadata: {} });
+		mockDocClient = { send: sendMock };
+	});
+
+	function createItem(i: number): DocumentWriteRequest {
+		return {
+			PutRequest: {
+				Item: {
+					testName: `test${i}`,
+					variants: [],
+					timestamp: '2024-01-01',
+				},
+			},
+		};
+	}
+
+	it('should write all items in a single batch when under 25', async () => {
+		const items = Array.from({ length: 10 }, (_, i) => createItem(i));
+
+		await writeBatch(
+			items,
+			'PROD',
+			mockDocClient as unknown as DynamoDBDocumentClient,
+		);
+
+		expect(sendMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('should chunk items into multiple batches when over 25', async () => {
+		const items = Array.from({ length: 28 }, (_, i) => createItem(i));
+
+		await writeBatch(
+			items,
+			'PROD',
+			mockDocClient as unknown as DynamoDBDocumentClient,
+		);
+
+		expect(sendMock).toHaveBeenCalledTimes(2);
+	});
+
+	it('should chunk exactly 25 items into one batch', async () => {
+		const items = Array.from({ length: 25 }, (_, i) => createItem(i));
+
+		await writeBatch(
+			items,
+			'PROD',
+			mockDocClient as unknown as DynamoDBDocumentClient,
+		);
+
+		expect(sendMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('should chunk 26 items into two batches', async () => {
+		const items = Array.from({ length: 26 }, (_, i) => createItem(i));
+
+		await writeBatch(
+			items,
+			'PROD',
+			mockDocClient as unknown as DynamoDBDocumentClient,
+		);
+
+		expect(sendMock).toHaveBeenCalledTimes(2);
+	});
+
+	it('should use correct table name with stage', async () => {
+		const items = [createItem(1)];
+
+		await writeBatch(
+			items,
+			'staging',
+			mockDocClient as unknown as DynamoDBDocumentClient,
+		);
+
+		const callArgs = (sendMock.mock.calls[0] as [unknown])[0] as {
+			input: { RequestItems: Record<string, unknown[]> };
+		};
+		expect(
+			callArgs.input.RequestItems['support-bandit-STAGING'],
+		).toBeDefined();
+	});
+});
+
+describe('buildWriteRequest', () => {
+	it('should build a valid write request', () => {
+		const rows: VariantQueryRow[] = [
+			{
+				test_name: 'test1',
+				variant_name: 'control',
+				views: 100,
+				sum_av_gbp: 50,
+				sum_av_gbp_per_view: 0.5,
+				acquisitions: 10,
+			},
+		];
+
+		const result = buildWriteRequest(rows, 'test1', 'Epic', '2024-01-01');
+
+		expect(result.PutRequest.Item).toEqual({
+			testName: 'Epic_test1',
+			variants: [
+				{
+					variantName: 'control',
+					annualisedValueInGBP: 50,
+					annualisedValueInGBPPerView: 0.5,
+					views: 100,
+				},
+			],
+			timestamp: '2024-01-01',
+		});
+	});
+});

--- a/bandit/src/query-lambda/dynamo.test.ts
+++ b/bandit/src/query-lambda/dynamo.test.ts
@@ -1,5 +1,5 @@
 import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
-import { buildWriteRequest, writeBatch } from './dynamo';
+import { buildWriteRequest, write } from './dynamo';
 import type { DocumentWriteRequest } from './dynamo';
 import type { VariantQueryRow } from './parse-result';
 
@@ -31,7 +31,7 @@ describe('writeBatch', () => {
 	it('should write all items in a single batch when under 25', async () => {
 		const items = Array.from({ length: 10 }, (_, i) => createItem(i));
 
-		await writeBatch(
+		await write(
 			items,
 			'PROD',
 			mockDocClient as unknown as DynamoDBDocumentClient,
@@ -43,7 +43,7 @@ describe('writeBatch', () => {
 	it('should chunk items into multiple batches when over 25', async () => {
 		const items = Array.from({ length: 28 }, (_, i) => createItem(i));
 
-		await writeBatch(
+		await write(
 			items,
 			'PROD',
 			mockDocClient as unknown as DynamoDBDocumentClient,
@@ -55,7 +55,7 @@ describe('writeBatch', () => {
 	it('should chunk exactly 25 items into one batch', async () => {
 		const items = Array.from({ length: 25 }, (_, i) => createItem(i));
 
-		await writeBatch(
+		await write(
 			items,
 			'PROD',
 			mockDocClient as unknown as DynamoDBDocumentClient,
@@ -67,7 +67,7 @@ describe('writeBatch', () => {
 	it('should chunk 26 items into two batches', async () => {
 		const items = Array.from({ length: 26 }, (_, i) => createItem(i));
 
-		await writeBatch(
+		await write(
 			items,
 			'PROD',
 			mockDocClient as unknown as DynamoDBDocumentClient,
@@ -79,7 +79,7 @@ describe('writeBatch', () => {
 	it('should use correct table name with stage', async () => {
 		const items = [createItem(1)];
 
-		await writeBatch(
+		await write(
 			items,
 			'staging',
 			mockDocClient as unknown as DynamoDBDocumentClient,

--- a/bandit/src/query-lambda/dynamo.ts
+++ b/bandit/src/query-lambda/dynamo.ts
@@ -54,18 +54,25 @@ function buildDynamoRecord(
 	};
 }
 
-export function writeBatch(
+const BATCH_SIZE = 25;
+
+export async function writeBatch(
 	batch: DocumentWriteRequest[],
 	stage: string,
 	docClient: DynamoDBDocumentClient,
 ): Promise<BatchWriteCommandOutput> {
 	const table = `support-bandit-${stage.toUpperCase()}`;
 
-	return docClient.send(
-		new BatchWriteCommand({
-			RequestItems: {
-				[table]: batch,
-			},
-		}),
-	);
+	let result: BatchWriteCommandOutput = { $metadata: {} };
+	for (let i = 0; i < batch.length; i += BATCH_SIZE) {
+		const chunk = batch.slice(i, i + BATCH_SIZE);
+		result = await docClient.send(
+			new BatchWriteCommand({
+				RequestItems: {
+					[table]: chunk,
+				},
+			}),
+		);
+	}
+	return result;
 }

--- a/bandit/src/query-lambda/dynamo.ts
+++ b/bandit/src/query-lambda/dynamo.ts
@@ -1,7 +1,4 @@
-import type {
-	BatchWriteCommandOutput,
-	DynamoDBDocumentClient,
-} from '@aws-sdk/lib-dynamodb';
+import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { BatchWriteCommand } from '@aws-sdk/lib-dynamodb';
 import type { VariantQueryRow } from './parse-result';
 
@@ -60,13 +57,11 @@ export async function write(
 	batch: DocumentWriteRequest[],
 	stage: string,
 	docClient: DynamoDBDocumentClient,
-): Promise<BatchWriteCommandOutput> {
+): Promise<void> {
 	const table = `support-bandit-${stage.toUpperCase()}`;
-
-	let result: BatchWriteCommandOutput = { $metadata: {} };
 	for (let i = 0; i < batch.length; i += CHUNK_SIZE) {
 		const chunk = batch.slice(i, i + CHUNK_SIZE);
-		result = await docClient.send(
+		await docClient.send(
 			new BatchWriteCommand({
 				RequestItems: {
 					[table]: chunk,
@@ -74,5 +69,4 @@ export async function write(
 			}),
 		);
 	}
-	return result;
 }

--- a/bandit/src/query-lambda/dynamo.ts
+++ b/bandit/src/query-lambda/dynamo.ts
@@ -54,9 +54,9 @@ function buildDynamoRecord(
 	};
 }
 
-const BATCH_SIZE = 25;
+const CHUNK_SIZE = 25;
 
-export async function writeBatch(
+export async function write(
 	batch: DocumentWriteRequest[],
 	stage: string,
 	docClient: DynamoDBDocumentClient,
@@ -64,8 +64,8 @@ export async function writeBatch(
 	const table = `support-bandit-${stage.toUpperCase()}`;
 
 	let result: BatchWriteCommandOutput = { $metadata: {} };
-	for (let i = 0; i < batch.length; i += BATCH_SIZE) {
-		const chunk = batch.slice(i, i + BATCH_SIZE);
+	for (let i = 0; i < batch.length; i += CHUNK_SIZE) {
+		const chunk = batch.slice(i, i + CHUNK_SIZE);
 		result = await docClient.send(
 			new BatchWriteCommand({
 				RequestItems: {

--- a/bandit/src/query-lambda/query-lambda.ts
+++ b/bandit/src/query-lambda/query-lambda.ts
@@ -14,7 +14,7 @@ import {
 	getDataForBanditTest,
 	getTotalComponentViewsForChannels,
 } from './bigquery';
-import { buildWriteRequest, writeBatch } from './dynamo';
+import { buildWriteRequest, write } from './dynamo';
 import { getSSMParam } from './ssm';
 
 const stage = process.env.STAGE;
@@ -151,5 +151,5 @@ export async function run(input: QueryLambdaInput): Promise<void> {
 		return;
 	}
 
-	await writeBatch(writeRequests, stage, docClient);
+	await write(writeRequests, stage, docClient);
 }


### PR DESCRIPTION
Chunk write requests into batches of 25 to satisfy DynamoDB's `BatchWriteItem` constraint. 

The query-lambda was attempting to write 28 items in a single batch, causing a `ValidationException`.