### PR TITLE
Filter unnecessary fields in bandit tests

### DIFF
--- a/bandit/src/get-bandit-tests/get-bandit-tests.ts
+++ b/bandit/src/get-bandit-tests/get-bandit-tests.ts
@@ -23,6 +23,10 @@ export async function run(): Promise<QueryLambdaInput> {
 	) as Test[];
 	const banditTests = filterBanditTests(tests);
 	return {
-		tests: banditTests,
+		tests: banditTests.map((test) => ({
+			name: test.name,
+			channel: test.channel,
+			methodologies: test.methodologies,
+		})),
 	};
 }


### PR DESCRIPTION
The first lambda in the state machine fetches bandit tests from dynamodb and outputs them, for use by the second lambda.
Currently it outputs the full test config, which is not necessary.
We've recently hit an aws limit for the size of the lambda output:
<img width="634" height="119" alt="Screenshot 2026-05-01 at 09 48 03" src="https://github.com/user-attachments/assets/38201a74-27fb-4998-a7ad-3c7aa5562f72" />

This PR filters out unnecessary fields.

The new output is shorter:
<img width="600" height="336" alt="Screenshot 2026-05-01 at 10 03 27" src="https://github.com/user-attachments/assets/f8bfa50b-2096-4468-a60c-9442a426c766" />
