### PR TITLE
Add timestamp parameter for bandit state machine

### DIFF
--- a/bandit/src/get-bandit-tests/get-bandit-tests.ts
+++ b/bandit/src/get-bandit-tests/get-bandit-tests.ts
@@ -17,7 +17,7 @@ const filterBanditTests = (tests: Test[]): Test[] =>
 			),
 	);
 
-export async function run(): Promise<QueryLambdaInput> {
+export async function run(event?: { timestamp?: string }): Promise<QueryLambdaInput> {
 	const tests = (await queryChannelTests(stage, docClient)).flatMap(
 		(test) => test.Items ?? [],
 	) as Test[];
@@ -28,5 +28,6 @@ export async function run(): Promise<QueryLambdaInput> {
 			channel: test.channel,
 			methodologies: test.methodologies,
 		})),
+		...(event?.timestamp !== undefined && { timestamp: event.timestamp }),
 	};
 }

--- a/bandit/src/get-bandit-tests/get-bandit-tests.ts
+++ b/bandit/src/get-bandit-tests/get-bandit-tests.ts
@@ -17,7 +17,9 @@ const filterBanditTests = (tests: Test[]): Test[] =>
 			),
 	);
 
-export async function run(event?: { timestamp?: string }): Promise<QueryLambdaInput> {
+export async function run(event?: {
+	timestamp?: string;
+}): Promise<QueryLambdaInput> {
 	const tests = (await queryChannelTests(stage, docClient)).flatMap(
 		(test) => test.Items ?? [],
 	) as Test[];

--- a/bandit/src/query-lambda/query-lambda.ts
+++ b/bandit/src/query-lambda/query-lambda.ts
@@ -69,7 +69,10 @@ export async function run(input: QueryLambdaInput): Promise<void> {
 	}
 
 	const ssmPath = `/bandit-testing/${stage}/gcp-wif-credentials-config`;
-	const date = input.timestamp !== undefined ? new Date(input.timestamp) : new Date(Date.now());
+	const date =
+		input.timestamp !== undefined
+			? new Date(input.timestamp)
+			: new Date(Date.now());
 	const currentHour = set(date, { minutes: 0, seconds: 0, milliseconds: 0 });
 	/**
 	 * Look back at the hour before last, to get a more complete set of events per hour.

--- a/bandit/src/query-lambda/query-lambda.ts
+++ b/bandit/src/query-lambda/query-lambda.ts
@@ -22,7 +22,7 @@ const docClient = DynamoDBDocumentClient.from(new DynamoDB({ region }));
 
 export interface QueryLambdaInput {
 	tests: Test[];
-	date?: Date;
+	timestamp?: string;
 }
 
 // Each test may contain 1 or more bandit methodologies
@@ -69,7 +69,7 @@ export async function run(input: QueryLambdaInput): Promise<void> {
 	}
 
 	const ssmPath = `/bandit-testing/${stage}/gcp-wif-credentials-config`;
-	const date = input.date ?? new Date(Date.now());
+	const date = input.timestamp !== undefined ? new Date(input.timestamp) : new Date(Date.now());
 	const currentHour = set(date, { minutes: 0, seconds: 0, milliseconds: 0 });
 	/**
 	 * Look back at the hour before last, to get a more complete set of events per hour.

--- a/bandit/src/scripts/backfill.ts
+++ b/bandit/src/scripts/backfill.ts
@@ -32,7 +32,7 @@ const tests = [{ name: testName, channel: channel }];
 const result = dates.reduce((prev, date) => {
 	return prev.then(() => {
 		console.log('Running for date', date);
-		return runQuery({ tests, date })
+		return runQuery({ tests, timestamp: date.toISOString() })
 			.then((result) => {
 				console.log(result);
 			})


### PR DESCRIPTION
This will enable us to manually run the state machine for missing hours. We had an outage earlier today and want to backfill the data.

Tested in CODE by manually running the state machine and checking the logs for the queries that were used:
1. without any input, it uses the default behaviour and queries for recent data (now - 1 hour)
2. with an input containing a timestamp field, it queries for a window 1 hour before the given timestamp

